### PR TITLE
[FIX] - fixed issue 71 with  a htmlspecialchars on the message to escape the url

### DIFF
--- a/Model/Mollie.php
+++ b/Model/Mollie.php
@@ -300,7 +300,7 @@ class Mollie extends AbstractMethod
         $paymentUrl = $payment->getCheckoutUrl();
         $transactionId = $payment->id;
 
-        $message = __('Customer redirected to Mollie, url: %1', $paymentUrl);
+        $message = htmlspecialchars(__('Customer redirected to Mollie, url: %1', $paymentUrl));
         $status = $this->mollieHelper->getStatusPending($storeId);
         $order->addStatusToHistory($status, $message, false);
         $order->setMollieTransactionId($transactionId);


### PR DESCRIPTION
- Added htmlspecialchars to escape the payment url in the sales_order_status_history
- To update existing records please run: 
```
UPDATE `sales_order_status_history` SET `comment` = REPLACE(`comment`, "&", "&amp;");
```