### PR TITLE
Get shipping amount including tax for refunds

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -648,7 +648,7 @@ class Orders extends AbstractModel
         if ($shippingCostsLine->getId() && $shippingCostsLine->getQtyRefunded() == 0) {
             if ($creditmemo->getShippingAmount() > 0) {
                 $addShippingToRefund = true;
-                if (abs($creditmemo->getShippingAmount() - $shippingCostsLine->getTotalAmount()) > 0.01) {
+                if (abs($creditmemo->getShippingInclTax() - $shippingCostsLine->getTotalAmount()) > 0.01) {
                     $msg = __('Can not create online refund, as shipping costs do not match');
                     $this->mollieHelper->addTolog('error', $msg);
                     throw new LocalizedException($msg);


### PR DESCRIPTION
Fix for issue #99 

"When using the Orders API, it is not possible to create a creditmemo in Magento for orders that contain a shipping amount including tax."

This will fix the following error message: "Can not create online refund, as shipping costs do not match"