### PR TITLE
Type and debug config settings to .env file

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -24,6 +24,7 @@
             <argument name="environment" xsi:type="array">
                 <item name="payment/mollie_general/apikey_test" xsi:type="string">1</item>
                 <item name="payment/mollie_general/apikey_live" xsi:type="string">1</item>
+                <item name="payment/mollie_general/type" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -25,6 +25,7 @@
                 <item name="payment/mollie_general/apikey_test" xsi:type="string">1</item>
                 <item name="payment/mollie_general/apikey_live" xsi:type="string">1</item>
                 <item name="payment/mollie_general/type" xsi:type="string">1</item>
+                <item name="payment/mollie_general/debug" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
These changes allow you to adjust the mode and debug settings per environment. For example, on production you can have the live mode and on dev the test mode. Debug mode, for example, you want to have on dev, but not on production. This is therefore environment specific.