### PR TITLE
Put the store name in the description

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -74,6 +74,7 @@ class General extends AbstractHelper
     const XML_PATH_PAYMENTLINK_ADD_MESSAGE = 'payment/mollie_methods_paymentlink/add_message';
     const XML_PATH_PAYMENTLINK_MESSAGE = 'payment/mollie_methods_paymentlink/message';
     const XML_PATH_API_METHOD = 'payment/%method%/method';
+    const XML_PATH_PAYMENT_DESCRIPTION = 'payment/%method%/payment_description';
     const XPATH_ISSUER_LIST_TYPE = 'payment/%method%/issuer_list_type';
 
     /**
@@ -814,5 +815,33 @@ class General extends AbstractHelper
                 $this->couponUsage->updateCustomerCouponTimesUsed($customerId, $this->coupon->getId(), false);
             }
         }
+    }
+
+    /**
+     * @param $method
+     * @param $orderNumber
+     * @param int $storeId
+     * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getPaymentDescription($method, $orderNumber, $storeId = 0)
+    {
+        $xpath = str_replace('%method%', $method, self::XML_PATH_PAYMENT_DESCRIPTION);
+        $description = $this->getStoreConfig($xpath);
+
+        if (!trim($description)) {
+            $description = '{ordernumber}';
+        }
+
+        $replacements = [
+            '{ordernumber}' => $orderNumber,
+            '{storename}' => $this->storeManager->getStore($storeId)->getName(),
+        ];
+
+        return str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            $description
+        );
     }
 }

--- a/Model/Adminhtml/Source/Method.php
+++ b/Model/Adminhtml/Source/Method.php
@@ -31,7 +31,7 @@ class Method implements ArrayInterface
         if (!$this->options) {
             $this->options = [
                 [
-                    'value' => '',
+                    'value' => 'payment',
                     'label' => __('Payments API')
                 ],
                 [

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -92,7 +92,7 @@ class Payments extends AbstractModel
         $method = $this->mollieHelper->getMethodCode($order);
         $paymentData = [
             'amount'         => $this->mollieHelper->getOrderAmountByOrder($order),
-            'description'    => $order->getIncrementId(),
+            'description'    => $order->getStore()->getName() . ': ' . $order->getIncrementId(),
             'billingAddress' => $this->getAddressLine($order->getBillingAddress()),
             'redirectUrl'    => $this->mollieHelper->getRedirectUrl($orderId, $paymentToken),
             'webhookUrl'     => $this->mollieHelper->getWebhookUrl(),

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -92,7 +92,7 @@ class Payments extends AbstractModel
         $method = $this->mollieHelper->getMethodCode($order);
         $paymentData = [
             'amount'         => $this->mollieHelper->getOrderAmountByOrder($order),
-            'description'    => $order->getStore()->getName() . ': ' . $order->getIncrementId(),
+            'description'    => $this->mollieHelper->getPaymentDescription($method, $order->getIncrementId()),
             'billingAddress' => $this->getAddressLine($order->getBillingAddress()),
             'redirectUrl'    => $this->mollieHelper->getRedirectUrl($orderId, $paymentToken),
             'webhookUrl'     => $this->mollieHelper->getWebhookUrl(),

--- a/Tests/Unit/Helper/GeneralTest.php
+++ b/Tests/Unit/Helper/GeneralTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Mollie\Payment\Helper;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class GeneralTest extends \PHPUnit\Framework\TestCase
+{
+    public function returnsTheCorrectDescriptionProvider()
+    {
+        return [
+            ['{ordernumber}', '0000025'],
+            ['', '0000025'],
+            ['{storename}', 'My Test Store'],
+            ['{storename}: {ordernumber}', 'My Test Store: 0000025'],
+            ['Order {ordernumber} from this store', 'Order 0000025 from this store'],
+        ];
+    }
+
+    /**
+     * @dataProvider returnsTheCorrectDescriptionProvider
+     */
+    public function testReturnsTheCorrectDescription($description, $expected)
+    {
+        $ob = new ObjectManager($this);
+
+        $storeConfigMock = $this->createMock(ScopeConfigInterface::class);
+        $storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $storeMock = $this->createMock(StoreInterface::class);
+
+        $storeManagerMock->method('getStore')->willReturn($storeMock);
+        $storeMock->method('getName')->willReturn('My Test Store');
+
+        $storeConfigMock->method('getValue')->willReturn($description);
+
+        /** @var \Mollie\Payment\Helper\General $instance */
+        $instance = $ob->getObject(\Mollie\Payment\Helper\General::class, [
+            'storeManager' => $storeManagerMock,
+        ]);
+
+        // The scopeConfig is burried in the context, use reflection to swap it with our mock
+        $property = (new \ReflectionObject($instance))->getProperty('scopeConfig');
+        $property->setAccessible(true);
+        $property->setValue($instance, $storeConfigMock);
+
+        $result = $instance->getPaymentDescription('ideal', '0000025');
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/etc/adminhtml/methods/bancontact.xml
+++ b/etc/adminhtml/methods/bancontact.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/bancontact.xml/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/bancontact.xml
+++ b/etc/adminhtml/methods/bancontact.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/bancontact.xml/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_bancontact/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/banktransfer.xml
+++ b/etc/adminhtml/methods/banktransfer.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_banktransfer/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -30,7 +39,7 @@
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
         </field>
-        <field id="order_status_pending" translate="label comment" type="select" sortOrder="4"
+        <field id="order_status_pending" translate="label comment" type="select" sortOrder="5"
                showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Status Pending</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Pending</source_model>
@@ -40,7 +49,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="due_days" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1"
+        <field id="due_days" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Due Days</label>
             <frontend_class>validate-number</frontend_class>

--- a/etc/adminhtml/methods/banktransfer.xml
+++ b/etc/adminhtml/methods/banktransfer.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_banktransfer/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_banktransfer/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="order_status_pending" translate="label comment" type="select" sortOrder="5"
                showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/belfius.xml
+++ b/etc/adminhtml/methods/belfius.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_belfius/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/belfius.xml
+++ b/etc/adminhtml/methods/belfius.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_belfius/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_belfius/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/bitcoin.xml
+++ b/etc/adminhtml/methods/bitcoin.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_bitcoin/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/bitcoin.xml
+++ b/etc/adminhtml/methods/bitcoin.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_bitcoin/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_bitcoin/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/creditcard.xml
+++ b/etc/adminhtml/methods/creditcard.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_creditcard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/creditcard.xml
+++ b/etc/adminhtml/methods/creditcard.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_creditcard/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_creditcard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/eps.xml
+++ b/etc/adminhtml/methods/eps.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_eps/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/eps.xml
+++ b/etc/adminhtml/methods/eps.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_eps/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_eps/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/giftcard.xml
+++ b/etc/adminhtml/methods/giftcard.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_giftcard/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_giftcard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">

--- a/etc/adminhtml/methods/giftcard.xml
+++ b/etc/adminhtml/methods/giftcard.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_giftcard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -30,7 +39,7 @@
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
         </field>
-        <field id="issuer_list_type" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Issuer List Style</label>
             <config_path>payment/mollie_methods_giftcard/issuer_list_type</config_path>

--- a/etc/adminhtml/methods/giropay.xml
+++ b/etc/adminhtml/methods/giropay.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_giropay/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_giropay/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/giropay.xml
+++ b/etc/adminhtml/methods/giropay.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_giropay/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/ideal.xml
+++ b/etc/adminhtml/methods/ideal.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_ideal/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -30,7 +39,7 @@
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
         </field>
-        <field id="issuer_list_type" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Issuer List Style</label>
             <config_path>payment/mollie_methods_ideal/issuer_list_type</config_path>
@@ -40,7 +49,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="add_qr" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
+        <field id="add_qr" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Add QR-Code option in Issuer List</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/adminhtml/methods/ideal.xml
+++ b/etc/adminhtml/methods/ideal.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_ideal/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_ideal/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">

--- a/etc/adminhtml/methods/inghomepay.xml
+++ b/etc/adminhtml/methods/inghomepay.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_inghomepay/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/inghomepay.xml
+++ b/etc/adminhtml/methods/inghomepay.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_inghomepay/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_inghomepay/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/kbc.xml
+++ b/etc/adminhtml/methods/kbc.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_kbc/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_kbc/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">

--- a/etc/adminhtml/methods/kbc.xml
+++ b/etc/adminhtml/methods/kbc.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_kbc/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -30,7 +39,7 @@
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
         </field>
-        <field id="issuer_list_type" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="issuer_list_type" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Issuer List Style</label>
             <config_path>payment/mollie_methods_kbc/issuer_list_type</config_path>

--- a/etc/adminhtml/methods/klarnapaylater.xml
+++ b/etc/adminhtml/methods/klarnapaylater.xml
@@ -18,15 +18,6 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_klarnapaylater/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>Payment from Applicable Countries</label>

--- a/etc/adminhtml/methods/klarnapaylater.xml
+++ b/etc/adminhtml/methods/klarnapaylater.xml
@@ -18,6 +18,15 @@
                 <field id="active">1</field>
             </depends>
         </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_klarnapaylater/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>Payment from Applicable Countries</label>

--- a/etc/adminhtml/methods/klarnasliceit.xml
+++ b/etc/adminhtml/methods/klarnasliceit.xml
@@ -18,15 +18,6 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_klarnasliceit/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>Payment from Applicable Countries</label>

--- a/etc/adminhtml/methods/klarnasliceit.xml
+++ b/etc/adminhtml/methods/klarnasliceit.xml
@@ -18,6 +18,15 @@
                 <field id="active">1</field>
             </depends>
         </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_klarnasliceit/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>Payment from Applicable Countries</label>

--- a/etc/adminhtml/methods/paymentlink.xml
+++ b/etc/adminhtml/methods/paymentlink.xml
@@ -18,15 +18,6 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_paymentlink/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
         <field id="add_message" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Add Link to Payment Details</label>

--- a/etc/adminhtml/methods/paymentlink.xml
+++ b/etc/adminhtml/methods/paymentlink.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="add_message" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_paymentlink/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="add_message" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Add Link to Payment Details</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -27,7 +36,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="message" translate="label" type="textarea" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="message" translate="label" type="textarea" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Payment Message / Link</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/adminhtml/methods/paypal.xml
+++ b/etc/adminhtml/methods/paypal.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_paypal/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/paypal.xml
+++ b/etc/adminhtml/methods/paypal.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_paypal/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_paypal/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/paysafecard.xml
+++ b/etc/adminhtml/methods/paysafecard.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_paysafecard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/paysafecard.xml
+++ b/etc/adminhtml/methods/paysafecard.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_paysafecard/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_paysafecard/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/methods/sofort.xml
+++ b/etc/adminhtml/methods/sofort.xml
@@ -18,7 +18,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
+        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_sofort/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+        </field>
+        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>

--- a/etc/adminhtml/methods/sofort.xml
+++ b/etc/adminhtml/methods/sofort.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_sofort/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_sofort/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -19,6 +19,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Bancontact</model>
                 <title>Bancontact</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -27,6 +28,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Banktransfer</model>
                 <title>Banktransfer</title>
+                <payment_description>{ordernumber}</payment_description>
                 <order_status_pending>pending_payment</order_status_pending>
                 <due_days>14</due_days>
                 <payment_action>order</payment_action>
@@ -37,6 +39,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Belfius</model>
                 <title>Belfius</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -45,6 +48,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Bitcoin</model>
                 <title>Bitcoin</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -53,6 +57,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Creditcard</model>
                 <title>Credit Cards</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -61,6 +66,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Ideal</model>
                 <title>iDeal</title>
+                <payment_description>{ordernumber}</payment_description>
                 <issuer_list_type>dropdown</issuer_list_type>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
@@ -70,6 +76,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Kbc</model>
                 <title>KBC/CBC</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <issuer_list_type>none</issuer_list_type>
                 <allowspecific>0</allowspecific>
@@ -79,6 +86,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Paypal</model>
                 <title>Paypal</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -87,6 +95,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Paysafecard</model>
                 <title>Paysafecard</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -95,6 +104,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Sofort</model>
                 <title>Sofort</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -103,6 +113,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Inghomepay</model>
                 <title>ING Homepay</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -111,6 +122,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Giropay</model>
                 <title>Giropay</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -119,6 +131,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Eps</model>
                 <title>EPS</title>
+                <payment_description>{ordernumber}</payment_description>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
                 <instructions/>
@@ -127,6 +140,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Klarnapaylater</model>
                 <title>Klarna Pay Later</title>
+                <payment_description>{ordernumber}</payment_description>
                 <method>order</method>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
@@ -136,6 +150,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Klarnasliceit</model>
                 <title>Klarna Slice It</title>
+                <payment_description>{ordernumber}</payment_description>
                 <method>order</method>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
@@ -145,6 +160,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Paymentlink</model>
                 <title>Mollie: Payment Link</title>
+                <payment_description>{ordernumber}</payment_description>
                 <method>order</method>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>
@@ -155,6 +171,7 @@
                 <active>0</active>
                 <model>Mollie\Payment\Model\Methods\Giftcard</model>
                 <title>Giftcard</title>
+                <payment_description>{ordernumber}</payment_description>
                 <issuer_list_type>dropdown</issuer_list_type>
                 <payment_action>order</payment_action>
                 <allowspecific>0</allowspecific>


### PR DESCRIPTION
This changes the description used by the payment api. The description would only contain the order number. This is now changed to `Storename: Ordernumber`. When you order in a stock Magento store the description would be something like: `Default store view: 0000025`.

Also see #112 