### PR TITLE
Feature/implemented przelewy24

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -161,10 +161,6 @@ class Orders extends AbstractModel
             $orderData['payment']['dueDate'] = $this->mollieHelper->getBanktransferDueDate($storeId);
         }
 
-        if ($method == 'przelewy24') {
-            $orderData['payment']['billingEmail'] = $order->getCustomerEmail();
-        }
-
         if (isset($additionalData['limited_methods'])) {
             $orderData['method'] = $additionalData['limited_methods'];
         }

--- a/etc/adminhtml/methods/przelewy24.xml
+++ b/etc/adminhtml/methods/przelewy24.xml
@@ -18,16 +18,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="payment_description" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Description</label>
-            <config_path>payment/mollie_methods_przelewy24/payment_description</config_path>
-            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
-            <strong>{ordernumber}</strong>: The order number for this transaction<br>
-            <strong>{storename}</strong>: The name of the store<br><br>
-            (Note: This only works when the method is set to Payments API)
-            ]]></comment>
-        </field>
-        <field id="method" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1"
+        <field id="method" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Method</label>
             <source_model>Mollie\Payment\Model\Adminhtml\Source\Method</source_model>
@@ -38,6 +29,19 @@
             <comment><![CDATA[<strong>Payment API</strong><br>Use the Payment API Platform for the transactions.<br><br>
             <strong>Order API</strong><br>Use the new Order API Platform and get additional insights in the orders.
             Read <a href="https://docs.mollie.com/orders/why-use-orders" target="_blank" >more.</a>]]></comment>
+        </field>
+        <field id="payment_description" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Description</label>
+            <config_path>payment/mollie_methods_przelewy24/payment_description</config_path>
+            <comment><![CDATA[The description to be used for this transaction. These variables are available:<br><br>
+            <strong>{ordernumber}</strong>: The order number for this transaction<br>
+            <strong>{storename}</strong>: The name of the store<br><br>
+            (Note: This only works when the method is set to Payments API)
+            ]]></comment>
+            <depends>
+                <field id="method">payment</field>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="allowspecific" translate="label" type="allowspecific" sortOrder="96" showInDefault="1"
                showInWebsite="1" showInStore="1">


### PR DESCRIPTION
- Removed the `billingEmail` for Orders API payments.
- Make the config dependent on the `enabled` and `method` options.