### PR TITLE
Extended on the Travis configuration:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 deploy:
   provider: releases
-  api_key: "TODO: Add the api key"
+  api_key: $GITHUB_API_KEY
   skip_cleanup: true
   file: Mollie_Payment.zip
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,30 @@
 language: php
 
-php:
-- 5.6
-- 7.0
-- 7.1
-- 7.2
-
-sudo: false
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+      env: MEQP_CHECK=true TOOLS_CHECK=true
+    - php: 7.3
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - "$HOME/.composer"
+    - "$HOME/.cache/composer"
+    - "$HOME/.composer/cache"
 
 script:
-- composer validate
-- find . -name '*.php' | xargs -n 1 -P4 php -l
+  - composer validate
+  - find . -name '*.php' | xargs -n 1 -P4 php -l
+  - sh travis.sh
+
+deploy:
+  provider: releases
+  api_key: "TODO: Add the api key"
+  skip_cleanup: true
+  file: Mollie_Payment.zip
+  on:
+    condition: MEQP_CHECK=true
+    tags: true

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,23 @@
+set -e
+set -x
+
+if [ "$MEQP_CHECK" = "true" ];
+then
+    composer global config http-basic.repo.magento.com $MAGENTO_USERNAME $MAGENTO_PASSWORD
+    composer config repositories.repo-magento-com composer https://repo.magento.com
+    composer require --no-interaction magento/marketplace-eqp
+
+    vendor/bin/phpcs --config-set installed_paths vendor/magento/marketplace-eqp
+    vendor/bin/phpcs -p --ignore=*/vendor/*,*/Tests/* -n --severity=9 --standard="MEQP2" ./
+    vendor/bin/phpcs -p -n --severity=9 --standard="MEQP2" ./Tests/
+fi
+
+if [ "$TOOLS_CHECK" = "true" ];
+then
+    # Create the package
+    git archive --format=zip --output=Mollie_Payment.zip $TRAVIS_COMMIT
+
+    git clone https://github.com/magento/marketplace-tools.git
+
+    php marketplace-tools/validate_m2_package.php -d Mollie_Payment.zip
+fi


### PR DESCRIPTION
- Implemented the Magento Marketplace EQP code sniffer: https://github.com/magento/marketplace-eqp
- Added the Magento tools: https://github.com/magento/marketplace-tools
- Zip the contents and upload to Github when this build is a tag.

There is on TODO in this PR that i cannot do as i don't have permissions for that: Set the api token. See this readme on how to do that:
https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token

Another TODO is to set the `$MAGENTO_USERNAME` and `$MAGENTO_PASSWORD` variables in the Travis configuration.