### PR TITLE
Remove use of proxies in constructor

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -18,7 +18,7 @@ use Magento\Sales\Model\OrderRepository;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\InvoiceRepository;
 use Magento\Sales\Model\Service\InvoiceService;
-use Magento\Checkout\Model\Session\Proxy as CheckoutSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Mollie\Payment\Helper\General as MollieHelper;
 use Mollie\Payment\Model\OrderLines;
 use Mollie\Payment\Service\Order\ProcessAdjustmentFee;

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -12,7 +12,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\OrderRepository;
-use Magento\Checkout\Model\Session\Proxy as CheckoutSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Mollie\Payment\Helper\General as MollieHelper;
 
 /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -29,4 +29,15 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Mollie\Payment\Model\Client\Orders">
+        <arguments>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Mollie\Payment\Model\Client\Payments">
+        <arguments>
+            <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
According to Magento technical guidelines:

> 2.5. Proxies and interceptors MUST NEVER be explicitly requested in constructors.

See: https://devdocs.magento.com/guides/v2.3/coding-standards/technical-guidelines.html