### PR TITLE
[WIP] Add stock logic to uncancel logic and make it (more) fail safe.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.zip
 .DS_Store
+/vendor/

--- a/Observer/SalesOrderUnCancelAfterCommit.php
+++ b/Observer/SalesOrderUnCancelAfterCommit.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Mollie\Payment\Observer;
+
+use Magento\CatalogInventory\Observer\ItemsForReindex;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Class SalesOrderUnCancelAfterCommit
+ * @ref \Magento\CatalogInventory\Observer\ReindexQuoteInventoryObserver
+ */
+class SalesOrderUnCancelAfterCommit implements ObserverInterface
+{
+    /**
+     * @var \Magento\CatalogInventory\Model\Indexer\Stock\Processor
+     */
+    protected $stockIndexerProcessor;
+
+    /**
+     * @var \Magento\CatalogInventory\Observer\ItemsForReindex
+     */
+    protected $itemsForReindex;
+
+    /**
+     * @param \Magento\CatalogInventory\Model\Indexer\Stock\Processor $stockIndexerProcessor
+     * @param ItemsForReindex $itemsForReindex
+     */
+    public function __construct(
+        \Magento\CatalogInventory\Model\Indexer\Stock\Processor $stockIndexerProcessor,
+        ItemsForReindex $itemsForReindex
+    ) {
+        $this->stockIndexerProcessor = $stockIndexerProcessor;
+        $this->itemsForReindex = $itemsForReindex;
+    }
+
+    /**
+     * Refresh stock index for specific stock items after successful order placement
+     *
+     * @param EventObserver $observer
+     * @return void
+     */
+    public function execute(EventObserver $observer)
+    {
+        /** @var \Magento\Sales\Model\Order $order */
+        $order = $observer->getEvent()->getData('order');
+        $productIds = [];
+        foreach ($order->getAllItems() as $item) {
+            /** @var \Magento\Sales\Model\Order\Item $item */
+            $productIds[$item->getProductId()] = $item->getProductId();
+            $children = $item->getChildrenItems();
+            if ($children) {
+                foreach ($children as $childItem) {
+                    /** @var \Magento\Sales\Model\Order\Item $childItem */
+                    $productIds[$childItem->getProductId()] = $childItem->getProductId();
+                }
+            }
+        }
+
+        if ($productIds) {
+            $this->stockIndexerProcessor->reindexList($productIds);
+        }
+    }
+}

--- a/Operation/UnCancelOrderOperation.php
+++ b/Operation/UnCancelOrderOperation.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Mollie\Payment\Operation;
+
+use Magento\CatalogInventory\Api\StockManagementInterface;
+use Magento\CatalogInventory\Observer\ItemsForReindex;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Mollie\Payment\Helper\General;
+use Magento\CatalogInventory\Api\RegisterProductSaleInterface;
+use Mollie\Payment\Operation\UnCancelOrderOperation\ProductQty;
+
+/**
+ * Class UnCancelOrderOperation
+ */
+class UnCancelOrderOperation
+{
+    /**
+     * @var \Magento\Framework\Event\ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * @var \Magento\Sales\Api\OrderRepositoryInterface
+     */
+    private $orderManagement;
+
+    /**
+     * @var \Mollie\Payment\Helper\General
+     */
+    private $generalHelper;
+
+    /**
+     * @var \Magento\CatalogInventory\Api\RegisterProductSaleInterface
+     */
+    private $registerProductSale;
+
+    /**
+     * @var StockManagementInterface|\Magento\CatalogInventory\Model\StockManagement
+     */
+    private $stockManagement;
+
+    /**
+     * @var \Mollie\Payment\Operation\UnCancelOrderOperation\ProductQty
+     */
+    private $productQty;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * UnCancelOrderOperation constructor.
+     *
+     * @param \Magento\Framework\Event\ManagerInterface                   $eventManager
+     * @param \Magento\Sales\Api\OrderRepositoryInterface                 $orderManagement
+     * @param \Magento\CatalogInventory\Api\StockManagementInterface      $stockManagement
+     * @param \Mollie\Payment\Operation\UnCancelOrderOperation\ProductQty $productQty
+     * @param \Mollie\Payment\Helper\General                              $generalHelper
+     * @param \Magento\Framework\App\ResourceConnection                   $resourceConnection
+     * RegisterProductSaleInterface is deprecated in 2.3.0 but we use it to allow backward compatibility
+     */
+    public function __construct(
+        ManagerInterface $eventManager,
+        OrderRepositoryInterface $orderManagement,
+        StockManagementInterface $stockManagement,
+        ProductQty $productQty,
+        General $generalHelper,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->orderManagement = $orderManagement;
+        $this->eventManager = $eventManager;
+        $this->generalHelper = $generalHelper;
+        $this->stockManagement = $stockManagement;
+        $this->productQty = $productQty;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order $order
+     * @param string                     $comment
+     * @param bool                       $graceful
+     * @return \Magento\Sales\Model\Order
+     * @throws \Exception
+     * @throws \Throwable
+     * Credits: https://github.com/Genmato/M2_UnCancelOrder/blob/master/Model/Order.php
+     */
+    public function execute($order, $comment = '', $graceful = true)
+    {
+        if (!$order->isCanceled() && $graceful) {
+            return $order;
+        }
+
+        if (!$order->isCanceled() && !$graceful) {
+            throw new \Magento\Framework\Exception\LocalizedException(__('We cannot un-cancel this order.'));
+        }
+
+        $connection = $this->resourceConnection->getConnection('sales');
+        $connection->beginTransaction();
+
+        $state = Order::STATE_PROCESSING;
+        $productStockQty = [];
+
+        foreach ($order->getAllVisibleItems() as $item) {
+            /** @var \Magento\Sales\Model\Order\Item $item */
+            if (!isset($productStockQty[$item->getProductId()])) {
+                $productStockQty[$item->getProductId()] = 0;
+            }
+            $productStockQty[$item->getProductId()] += $item->getQtyCanceled();
+            foreach ($item->getChildrenItems() as $child) {
+                /** @var \Magento\Sales\Model\Order\Item $child */
+                if (!isset($productStockQty[$item->getProductId()])) {
+                    $productStockQty[$child->getProductId()] = 0;
+                }
+                $productStockQty[$child->getProductId()] += $item->getQtyCanceled();
+                $child->setQtyCanceled(0);
+                $child->setTaxCanceled(0);
+                $child->setDiscountTaxCompensationCanceled(0);
+            }
+            $item->setQtyCanceled(0);
+            $item->setTaxCanceled(0);
+            $item->setDiscountTaxCompensationCanceled(0);
+            $this->eventManager->dispatch('sales_order_item_uncancel', ['item' => $item]);
+        }
+
+        /** @ref Magento\CatalogInventory\Observer\SubtractQuoteInventoryObserver */
+        $items = $this->productQty->getProductQty($order->getAllItems());
+        $this->registerProductSale->registerProductsSale($productStockQty);
+        $this->stockManagement->registerProductsSale(
+            $items,
+            $order->getStore()->getWebsiteId()
+        );
+
+        $order->setSubtotalCanceled(0);
+        $order->setBaseSubtotalCanceled(0);
+        $order->setTaxCanceled(0);
+        $order->setBaseTaxCanceled(0);
+        $order->setShippingCanceled(0);
+        $order->setBaseShippingCanceled(0);
+        $order->setDiscountCanceled(0);
+        $order->setBaseDiscountCanceled(0);
+        $order->setTotalCanceled(0);
+        $order->setBaseTotalCanceled(0);
+        $order->setState($state);
+        $order->setStatus($this->generalHelper->getStatusPending($order->getStoreId()));
+
+        if (!empty($comment)) {
+            $order->addStatusHistoryComment($comment, false);
+        }
+
+        $connection->beginTransaction();
+
+        try {
+            $this->orderManagement->save($order);
+            $connection->commit();
+        } catch (\Throwable $e) {
+            $connection->rollBack();
+            throw $e;
+        }
+
+        $this->eventManager->dispatch('sales_order_uncancel_after_commit', ['order' => $order]);
+
+        return $order;
+    }
+}

--- a/Operation/UnCancelOrderOperation/ProductQty.php
+++ b/Operation/UnCancelOrderOperation/ProductQty.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Mollie\Payment\Operation\UnCancelOrderOperation;
+
+use Magento\Sales\Model\Order\Item as OrderItem;
+
+/**
+ * Class ProductQty
+ * @ref \Magento\CatalogInventory\Observer\ProductQty
+ */
+class ProductQty
+{
+    /**
+     * Prepare array with information about used product qty and product stock item
+     *
+     * @param array $relatedItems
+     * @return array
+     */
+    public function getProductQty($relatedItems)
+    {
+        $items = [];
+        foreach ($relatedItems as $item) {
+            $productId = $item->getProductId();
+            if (!$productId) {
+                continue;
+            }
+            $children = $item->getChildrenItems();
+            if ($children) {
+                foreach ($children as $childItem) {
+                    $this->addItemToQtyArray($childItem, $items);
+                }
+            } else {
+                $this->addItemToQtyArray($item, $items);
+            }
+        }
+        return $items;
+    }
+
+    /**
+     * Adds stock item qty to $items (creates new entry or increments existing one)
+     *
+     * @param OrderItem $quoteItem
+     * @param array &$items
+     * @return void
+     */
+    protected function addItemToQtyArray(OrderItem $quoteItem, &$items)
+    {
+        $productId = $quoteItem->getProductId();
+        if (!$productId) {
+            return;
+        }
+        if (isset($items[$productId])) {
+            $items[$productId] += $quoteItem->getQtyCanceled();
+        } else {
+            $items[$productId] = $quoteItem->getQtyCanceled();
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "require": {
     "mollie/mollie-api-php": "^2.1",
     "magento/framework": ">=100.1.0",
+    "magento/module-sales": ">=100.1.0",
     "ext-json": "*"
   },
   "type": "magento2-module",

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -15,4 +15,7 @@
     <event name="sales_order_creditmemo_save_after">
         <observer name="mollie_create_online_refund" instance="Mollie\Payment\Observer\SalesOrderCreditmemoSaveAfter"/>
     </event>
+    <event name="sales_order_uncancel_after_commit">
+        <observer name="mollie_uncancel_reindex" instance="Mollie\Payment\Observer\SalesOrderUnCancelAfterCommit" />
+    </event>
 </config>


### PR DESCRIPTION
Currently the uncancel logic is insufficient to work properly with Magento 2.3.x. Since the introduction of MSI the inventory relies on reservations to manage the salable stock. Currently no stock reservation added when an order is uncancelled resulting in corrupt reservations (the reservation logic is very flimsy if you ask me, but we'll have to deal with it).

This has not been tested (yet).