### PR TITLE
When the locale option was set to 'store', but the shop locale was not in the list of allowed locales you would get a 422 error

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -558,7 +558,7 @@ class General extends AbstractHelper
             }
         }
 
-        if ($locale) {
+        if ($locale && $locale != 'store') {
             return $locale;
         }
 

--- a/Test/Integration/Helper/GeneralTest.php
+++ b/Test/Integration/Helper/GeneralTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Mollie\Payment\Test\Integration\Helper;
+
+use Magento\Framework\Locale\Resolver;
+use Mollie\Payment\Helper\General;
+use Mollie\Payment\Test\Integration\TestCase;
+
+class GeneralTest extends TestCase
+{
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/locale en_US
+     */
+    public function testGetLocaleCodeWithFixedLocale()
+    {
+        /** @var General $instance */
+        $instance = $this->objectManager->get(General::class);
+
+        $result = $instance->getLocaleCode(null, 'order');
+
+        $this->assertEquals('en_US', $result);
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/locale
+     */
+    public function testGetLocaleCodeWithAutomaticDetectionAndAValidLocale()
+    {
+        /** @var Resolver $localeResolver */
+        $localeResolver = $this->objectManager->get(Resolver::class);
+        $localeResolver->setLocale('en_US');
+
+        /** @var General $instance */
+        $instance = $this->objectManager->get(General::class);
+
+        $result = $instance->getLocaleCode(null, 'order');
+
+        $this->assertEquals('en_US', $result);
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/locale
+     */
+    public function testGetLocaleCodeWithAutomaticDetectionAndAInvalidLocale()
+    {
+        /** @var Resolver $localeResolver */
+        $localeResolver = $this->objectManager->get(Resolver::class);
+        $localeResolver->setLocale('en_GB');
+
+        /** @var General $instance */
+        $instance = $this->objectManager->get(General::class);
+
+        $result = $instance->getLocaleCode(null, 'order');
+
+        $this->assertEquals('en_US', $result);
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/locale store
+     */
+    public function testGetLocaleCodeBasedOnTheStoreLocaleWithAValidValue()
+    {
+        /** @var Resolver $localeResolver */
+        $localeResolver = $this->objectManager->get(Resolver::class);
+        $localeResolver->setLocale('en_GB');
+
+        /** @var General $instance */
+        $instance = $this->objectManager->get(General::class);
+
+        $result = $instance->getLocaleCode(null, 'order');
+
+        $this->assertEquals('en_US', $result);
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/locale
+     */
+    public function testGetLocaleCanReturnNull()
+    {
+        /** @var Resolver $localeResolver */
+        $localeResolver = $this->objectManager->get(Resolver::class);
+        $localeResolver->setLocale('en_GB');
+
+        /** @var General $instance */
+        $instance = $this->objectManager->get(General::class);
+
+        $result = $instance->getLocaleCode(null, 'payment');
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.

**Please describe the bug/feature/etc this PR contains:**

When the locale option was set to 'store', but the shop locale was not in the list of allowed locales you would get a 422 error.

**Scenario to test this code:**

- Set the configuration option `payment/mollie_general/locale` to `Store`.
- Change the language of the store view to `en_GB` (`General -> Locale Options -> Locale`)

Try to place an order. You will get this exception:
"Error executing API call (422: Unprocessable Entity): The locale is invalid. Field: locale."