### PR TITLE
Allow to create invoice for the Klarna methods on the moment the ship…

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -65,6 +65,7 @@ class General extends AbstractHelper
     const XML_PATH_STATUS_PENDING = 'payment/mollie_general/order_status_pending';
     const XML_PATH_STATUS_PENDING_BANKTRANSFER = 'payment/mollie_methods_banktransfer/order_status_pending';
     const XML_PATH_BANKTRANSFER_DUE_DAYS = 'payment/mollie_methods_banktransfer/due_days';
+    const XML_PATH_INVOICE_MOMENT = 'payment/mollie_general/invoice_moment';
     const XML_PATH_INVOICE_NOTIFY = 'payment/mollie_general/invoice_notify';
     const XML_PATH_LOCALE = 'payment/mollie_general/locale';
     const XML_PATH_IMAGES = 'payment/mollie_general/payment_images';
@@ -441,6 +442,16 @@ class General extends AbstractHelper
     public function getStatusPendingBanktransfer($storeId = 0)
     {
         return $this->getStoreConfig(self::XML_PATH_STATUS_PENDING_BANKTRANSFER, $storeId);
+    }
+
+    /**
+     * @see \Mollie\Payment\Model\Adminhtml\Source\InvoiceMoment
+     * @param int $storeId
+     * @return string
+     */
+    public function getInvoiceMoment($storeId = 0)
+    {
+        return $this->getStoreConfig(static::XML_PATH_INVOICE_MOMENT, $storeId);
     }
 
     /**

--- a/Model/Adminhtml/Source/InvoiceMoment.php
+++ b/Model/Adminhtml/Source/InvoiceMoment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mollie\Payment\Model\Adminhtml\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class InvoiceMoment implements OptionSourceInterface
+{
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => 'authorize',
+                'label' => __('On Authorize'),
+            ],
+            [
+                'value' => 'shipment',
+                'label' => __('On Shipment'),
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Model/Adminhtml/Source/InvoiceMomentTest.php
+++ b/Test/Unit/Model/Adminhtml/Source/InvoiceMomentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Mollie\Payment\Test\Unit\Model\Adminhtml\Source;
+
+use Mollie\Payment\Model\Adminhtml\Source\InvoiceMoment;
+use Mollie\Payment\Test\Unit\UnitTestCase;
+
+class InvoiceMomentTest extends UnitTestCase
+{
+    public function containsTheCorrectOptionsProvider()
+    {
+        return [
+            ['authorize'],
+            ['shipment'],
+        ];
+    }
+
+    /**
+     * @dataProvider containsTheCorrectOptionsProvider
+     */
+    public function testContainsTheCorrectOptions($expected)
+    {
+        $instance = $this->objectManager->getObject(InvoiceMoment::class);
+
+        $result = $instance->toOptionArray();
+
+        $values = array_map(function ($value) { return $value['value']; }, $result);
+
+        $this->assertContains($expected, $values);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -95,34 +95,41 @@
                         <config_path>payment/mollie_general/order_status_processing</config_path>
                         <comment><![CDATA[Set the order status for Completed Payments]]></comment>
                     </field>
-                    <field id="invoice_notify" translate="label comment" type="select" sortOrder="25" showInDefault="1"
+                    <field id="invoice_moment" translate="label comment" type="select" sortOrder="26" showInDefault="1"
+                           showInWebsite="1" showInStore="1">
+                        <label>When to create the invoice?</label>
+                        <source_model>Mollie\Payment\Model\Adminhtml\Source\InvoiceMoment</source_model>
+                        <config_path>payment/mollie_general/invoice_moment</config_path>
+                        <comment><![CDATA[When do we create the invoice?<br><strong>On Authorize</strong>: Create a full invoice when the order is authorized.<br><strong>On Shipment</strong>: Create a (partial) invoice when a shipment is created.]]></comment>
+                    </field>
+                    <field id="invoice_notify" translate="label comment" type="select" sortOrder="27" showInDefault="1"
                            showInWebsite="1" showInStore="1">
                         <label>Send Invoice Email</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mollie_general/invoice_notify</config_path>
                         <comment><![CDATA[Set the notification for to Notify the customer with the Invoice]]></comment>
                     </field>
-                    <field id="locale" translate="label comment" type="select" sortOrder="26" showInDefault="1"
+                    <field id="locale" translate="label comment" type="select" sortOrder="28" showInDefault="1"
                            showInWebsite="1" showInStore="1">
                         <label>Language Payment Page</label>
                         <source_model>Mollie\Payment\Model\Adminhtml\Source\Locale</source_model>
                         <config_path>payment/mollie_general/locale</config_path>
                         <comment><![CDATA[Let Mollie automatically detect the language or force the language from the store view.]]></comment>
                     </field>
-                    <field id="currency" translate="label" type="select" sortOrder="27" showInDefault="1"
+                    <field id="currency" translate="label" type="select" sortOrder="29" showInDefault="1"
                            showInWebsite="1" showInStore="1">
                         <label>Use Base Currency</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/mollie_general/currency</config_path>
                         <comment>Force use of base currency for the payment request. Is set to no the selected currency of the storeview will be used for request.</comment>
                     </field>
-                    <field id="transaction_details" translate="label" type="select" sortOrder="28" showInDefault="1"
+                    <field id="transaction_details" translate="label" type="select" sortOrder="30" showInDefault="1"
                            showInWebsite="0" showInStore="0">
                         <label>Show Transaction Details</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <comment>Display Transaction Details like e.g. IBAN, BIC, Paypal Reference, Card Holder etc.</comment>
                     </field>
-                    <field id="cancel_failed_orders" translate="label" type="select" sortOrder="29" showInDefault="1"
+                    <field id="cancel_failed_orders" translate="label" type="select" sortOrder="31" showInDefault="1"
                            showInWebsite="0" showInStore="1">
                         <label>Cancel the order when the connection fails</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,6 +9,7 @@
                 <payment_images>1</payment_images>
                 <order_status_pending>pending_payment</order_status_pending>
                 <order_status_processing>processing</order_status_processing>
+                <invoice_moment>authorize</invoice_moment>
                 <invoice_notify>1</invoice_notify>
                 <loading_screen>0</loading_screen>
                 <debug>1</debug>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -82,3 +82,5 @@
 "Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment."
 "Warning: we recommend to use a unique payment status for pending Banktransfer payments","Warning: we recommend to use a unique payment status for pending Banktransfer payments"
 "<strong>Please note:</strong> This payment method is only visible when the device of the user Apple Pay has enabled and the checkout is served over HTTPS.","<strong>Please note:</strong> This payment method is only visible when the device of the user Apple Pay has enabled and the checkout is served over HTTPS."
+When to create the invoice?,When to create the invoice?
+"When do we create the invoice?<br><strong>On authorize</strong>: Create a full invoice when the order is authorized.<br><strong>On shipment</strong>: Create a (partial) invoice when a shipment is created.","When do we create the invoice?<br><strong>On authorize</strong>: Create a full invoice when the order is authorized.<br><strong>On shipment</strong>: Create a (partial) invoice when a shipment is created."


### PR DESCRIPTION
…ment is created

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [X] I have added an scenario to test my changes.

**Please describe the bug/feature/etc this PR contains:**

This allows defer the creation of the invoice from the moment the order is "authorized" to the moment that the order is shipped. This allows for partial invoices.

**Scenario to test this code:**

Open the config and change the `When to create the invoice?` setting to `On Shipment`. Create a new Klarna Slice It or Pay Later order. You won't see an order at this moment. Create a (partial or full) shipment, and you will see an invoice representing the shipped items.