### PR TITLE
Catch error when sending emails. This prevents that multiple emails are being sent

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -352,15 +352,25 @@ class Orders extends AbstractModel
                 $sendInvoice = $this->mollieHelper->sendInvoice($storeId);
 
                 if (!$order->getEmailSent()) {
-                    $this->orderSender->send($order);
-                    $message = __('New order email sent');
-                    $this->orderCommentHistory->add($order, $message, true);
+                    try {
+                        $this->orderSender->send($order, true);
+                        $message = __('New order email sent');
+                        $this->orderCommentHistory->add($order, $message, true);
+                    } catch (\Throwable $exception) {
+                        $message = __('Unable to send the new order email: %1', $exception->getMessage());
+                        $this->orderCommentHistory->add($order, $message, false);
+                    }
                 }
 
                 if ($invoice && !$invoice->getEmailSent() && $sendInvoice) {
-                    $this->invoiceSender->send($invoice);
-                    $message = __('Notified customer about invoice #%1', $invoice->getIncrementId());
-                    $this->orderCommentHistory->add($order, $message, true);
+                    try {
+                        $this->invoiceSender->send($invoice);
+                        $message = __('Notified customer about invoice #%1', $invoice->getIncrementId());
+                        $this->orderCommentHistory->add($order, $message, true);
+                    } catch (\Throwable $exception) {
+                        $message = __('Unable to send the invoice: %1', $exception->getMessage());
+                        $this->orderCommentHistory->add($order, $message, true);
+                    }
                 }
 
             }
@@ -379,8 +389,13 @@ class Orders extends AbstractModel
 
         if ($mollieOrder->isCreated()) {
             if ($mollieOrder->method == 'banktransfer' && !$order->getEmailSent()) {
-                $this->orderSender->send($order);
-                $message = __('New order email sent');
+                try {
+                    $this->orderSender->send($order);
+                    $message = __('New order email sent');
+                } catch (\Throwable $exception) {
+                    $message = __('Unable to send the new order email: %1', $exception->getMessage());
+                }
+
                 if (!$statusPending = $this->mollieHelper->getStatusPendingBanktransfer($storeId)) {
                     $statusPending = $order->getStatus();
                 }


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.

**Please describe the bug/feature/etc this PR contains:**

When there is invalid in one of the order or invoice emails, an exception will be thrown. As everything is handled within a transaction, this is not transaction is never finished and an error is returned to the webhook. Mollie will keep retrying for some time, and though some of the emails might keep sending.

**Scenario to test this code:**

- Create a new e-mail template and make sure this bogus code is in there:
  `{{trans 'Placed on <span class="no-link">%created_at</span>' created_at=$order.BigFatError(2) |raw}}`
- Configure it to be used (Config -> Sales -> Sales Emails).
- Place an order.