### PR TITLE
Execute the $order->cancel() method so the `sales_order_payment_cancel` event is thrown

### DIFF
--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -310,7 +310,9 @@ class Payments extends AbstractModel
         if ($status == 'canceled' || $status == 'failed' || $status == 'expired') {
             if ($type == 'webhook') {
                 $this->mollieHelper->registerCancellation($order, $status);
+                $order->cancel();
             }
+
             $msg = ['success' => false, 'status' => $status, 'order_id' => $orderId, 'type' => $type];
             $this->mollieHelper->addTolog('success', $msg);
             return $msg;


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.
