### PR TITLE
Bugfix: There is always an orderLine object returned, but it can be empty when no records found

### DIFF
--- a/Model/OrderLines.php
+++ b/Model/OrderLines.php
@@ -420,7 +420,8 @@ class OrderLines extends AbstractModel
             $orderLines[] = ['id' => $shippingFeeItemLine->getLineId(), 'quantity' => 1];
         }
 
-        if ($storeCreditLine = $this->getStoreCreditItemLineOrder($orderId)) {
+        $storeCreditLine = $this->getStoreCreditItemLineOrder($orderId);
+        if ($storeCreditLine->getId()) {
             $orderLines[] = ['id' => $storeCreditLine->getLineId(), 'quantity' => 1];
         }
 


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.