### PR TITLE
Bugfix: The correct store name is now used when using the {storename} variable in the payment description

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -16,6 +16,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
+use Magento\Store\Model\Information;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Config\Model\ResourceModel\Config;
 use Magento\Payment\Helper\Data as PaymentHelper;
@@ -858,7 +859,7 @@ class General extends AbstractHelper
     public function getPaymentDescription($method, $orderNumber, $storeId = 0)
     {
         $xpath = str_replace('%method%', 'mollie_methods_' . $method, self::XML_PATH_PAYMENT_DESCRIPTION);
-        $description = $this->getStoreConfig($xpath);
+        $description = $this->getStoreConfig($xpath, $storeId);
 
         if (!trim($description)) {
             $description = '{ordernumber}';
@@ -866,7 +867,7 @@ class General extends AbstractHelper
 
         $replacements = [
             '{ordernumber}' => $orderNumber,
-            '{storename}' => $this->storeManager->getStore($storeId)->getName(),
+            '{storename}' => $this->getStoreConfig(Information::XML_PATH_STORE_INFO_NAME, $storeId),
         ];
 
         return str_replace(

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -100,7 +100,7 @@ class Payments extends AbstractModel
         $method = $this->mollieHelper->getMethodCode($order);
         $paymentData = [
             'amount'         => $this->mollieHelper->getOrderAmountByOrder($order),
-            'description'    => $this->mollieHelper->getPaymentDescription($method, $order->getIncrementId()),
+            'description'    => $this->mollieHelper->getPaymentDescription($method, $order->getIncrementId(), $storeId),
             'billingAddress' => $this->getAddressLine($order->getBillingAddress()),
             'redirectUrl'    => $this->mollieHelper->getRedirectUrl($orderId, $paymentToken),
             'webhookUrl'     => $this->mollieHelper->getWebhookUrl(),


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.