### PR TITLE
Fix when method is unavailable after switching country

### DIFF
--- a/view/frontend/web/js/view/checkout/save-payment-method.js
+++ b/view/frontend/web/js/view/checkout/save-payment-method.js
@@ -31,6 +31,9 @@ define([
             }, this, 'beforeChange');
 
             quote.paymentMethod.subscribe( function (newValue) {
+                if (!newValue) {
+                    return;
+                }
                 // If the old method was a payment fee method we also need to update
                 if (isApplicableMethod(oldMethod) || isApplicableMethod(newValue.method)) {
                     this.savePaymentMethod(newValue.method);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**Please describe the bug/feature/etc this PR contains:**

When I change country in the checkout a payment method can become unavailable. Currently the module does not check this and gives an error.

**Scenario to test this code:**
Have a payment method C that is not available in country BE.
Go to checkout with default country NL and select payment method C
Choose country BE
Payment method C becomes unavailable and module gives an error