### PR TITLE
Fix: Use the correct pending payment status for banktransfer

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -923,4 +923,22 @@ class General extends AbstractHelper
 
         return end($payments)->status;
     }
+
+    /**
+     * @param OrderInterface $order
+     * @return string
+     */
+    public function getPendingPaymentStatus(OrderInterface $order)
+    {
+        $status = null;
+        if ($order->getPayment()->getMethod() == 'mollie_methods_banktransfer') {
+            $status = $this->config->statusPendingBanktransfer($order->getStoreId());
+        }
+
+        if (!$status) {
+            $status = $this->config->orderStatusPending($order->getStoreId());
+        }
+
+        return $status;
+    }
 }

--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -304,10 +304,7 @@ class Orders extends AbstractModel
 
         $this->orderLines->linkOrderLines($mollieOrder->lines, $order);
 
-        $status = $this->config->orderStatusPending($order->getStoreId());
-        if ($order->getPayment()->getMethod() == 'mollie_methods_banktransfer') {
-            $status = $this->config->statusPendingBanktransfer($order->getStoreId());
-        }
+        $status = $this->mollieHelper->getPendingPaymentStatus($order);
 
         $msg = __('Customer redirected to Mollie');
         if ($order->getPayment()->getMethodInstance()->getCode() == 'mollie_methods_paymentlink') {

--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -25,6 +25,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Types\OrderStatus;
+use Mollie\Payment\Config;
 use Mollie\Payment\Helper\General as MollieHelper;
 use Mollie\Payment\Model\Adminhtml\Source\InvoiceMoment;
 use Mollie\Payment\Model\OrderLines;
@@ -123,6 +124,10 @@ class Orders extends AbstractModel
      * @var BuildTransaction
      */
     private $buildTransaction;
+    /**
+     * @var Config
+     */
+    private $config;
 
     /**
      * Orders constructor.
@@ -146,6 +151,7 @@ class Orders extends AbstractModel
      * @param State                 $orderState
      * @param Transaction           $transaction
      * @param BuildTransaction      $buildTransaction
+     * @param Config                $config
      */
     public function __construct(
         OrderLines $orderLines,
@@ -166,7 +172,8 @@ class Orders extends AbstractModel
         Expires $expires,
         State $orderState,
         Transaction $transaction,
-        BuildTransaction $buildTransaction
+        BuildTransaction $buildTransaction,
+        Config $config
     ) {
         $this->orderLines = $orderLines;
         $this->orderSender = $orderSender;
@@ -187,6 +194,7 @@ class Orders extends AbstractModel
         $this->orderState = $orderState;
         $this->transaction = $transaction;
         $this->buildTransaction = $buildTransaction;
+        $this->config = $config;
     }
 
     /**
@@ -296,7 +304,10 @@ class Orders extends AbstractModel
 
         $this->orderLines->linkOrderLines($mollieOrder->lines, $order);
 
-        $status = $this->mollieHelper->getStatusPending($order->getStoreId());
+        $status = $this->config->orderStatusPending($order->getStoreId());
+        if ($order->getPayment()->getMethod() == 'mollie_methods_banktransfer') {
+            $status = $this->config->statusPendingBanktransfer($order->getStoreId());
+        }
 
         $msg = __('Customer redirected to Mollie');
         if ($order->getPayment()->getMethodInstance()->getCode() == 'mollie_methods_paymentlink') {

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -186,10 +186,7 @@ class Payments extends AbstractModel
             $order->getPayment()->setAdditionalInformation('expires_at', $payment->expiresAt);
         }
 
-        $status = $this->config->orderStatusPending($order->getStoreId());
-        if ($order->getPayment()->getMethod() == 'mollie_methods_banktransfer') {
-            $status = $this->config->statusPendingBanktransfer($order->getStoreId());
-        }
+        $status = $this->mollieHelper->getPendingPaymentStatus($order);
 
         $order->addStatusToHistory($status, __('Customer redirected to Mollie'), false);
         $order->setMollieTransactionId($payment->id);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.
