### PR TITLE
Bugfix: The graphql query 'mollie_available_issuers' would throw an error

### DIFF
--- a/GraphQL/Resolver/Cart/AvailableIssuersForMethod.php
+++ b/GraphQL/Resolver/Cart/AvailableIssuersForMethod.php
@@ -9,8 +9,11 @@ namespace Mollie\Payment\GraphQL\Resolver\Cart;
 use Mollie\Payment\Helper\General;
 use Mollie\Payment\Model\Mollie;
 use Mollie\Payment\Service\Mollie\GetIssuers;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
-class AvailableIssuersForMethod
+class AvailableIssuersForMethod implements ResolverInterface
 {
     /**
      * @var Mollie
@@ -40,7 +43,7 @@ class AvailableIssuersForMethod
     /**
      * @inheritDoc
      */
-    public function resolve($field, $context, $info, array $value = null, array $args = null)
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
         $storeId = $context->getExtensionAttributes()->getStore()->getId();
         $method = $value['code'];

--- a/Model/Mollie.php
+++ b/Model/Mollie.php
@@ -569,7 +569,7 @@ class Mollie extends AbstractMethod
      * @param $method
      * @param $issuerListType
      *
-     * @return array
+     * @return array|null
      */
     public function getIssuers($mollieApi, $method, $issuerListType)
     {
@@ -583,6 +583,10 @@ class Mollie extends AbstractMethod
 
         try {
             $issuersList = $mollieApi->methods->get($methodCode, ["include" => "issuers"])->issuers;
+            if (!$issuersList) {
+                return null;
+            }
+
             foreach ($issuersList as $issuer) {
                 $issuers[] = $issuer;
             }

--- a/Service/Mollie/GetIssuers.php
+++ b/Service/Mollie/GetIssuers.php
@@ -44,11 +44,11 @@ class GetIssuers
      * @param MollieApiClient $mollieApi
      * @param string $method
      * @param string $type On of: dropdown, radio, none
-     * @return array
+     * @return array|null
      */
     public function execute(MollieApiClient $mollieApi, $method, $type)
     {
-        $identifier = static::CACHE_IDENTIFIER_PREFIX . $method;
+        $identifier = static::CACHE_IDENTIFIER_PREFIX . $method . $type;
         $result = $this->cache->load($identifier);
         if ($result) {
             return $this->serializer->unserialize($result);
@@ -70,11 +70,19 @@ class GetIssuers
         return $result;
     }
 
+    /**
+     * @param $storeId
+     * @param $method
+     * @return array|null
+     */
     public function getForGraphql($storeId, $method)
     {
         $mollieApi = $this->mollieModel->getMollieApi($storeId);
 
         $issuers = $this->execute($mollieApi, $method, 'radio');
+        if (!$issuers) {
+            return null;
+        }
 
         $output = [];
         foreach ($issuers as $issuer) {


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
- [X] GraphQL

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...