### PR TITLE
Bugfix: Add a valid rest api schema

### DIFF
--- a/Api/Webapi/GetCustomerOrderInterface.php
+++ b/Api/Webapi/GetCustomerOrderInterface.php
@@ -10,7 +10,7 @@ interface GetCustomerOrderInterface
 {
     /**
      * @param string $hash
-     * @return array
+     * @return mixed[]
      */
     public function byHash(string $hash): array;
 }

--- a/Api/Webapi/StartTransactionRequestInterface.php
+++ b/Api/Webapi/StartTransactionRequestInterface.php
@@ -9,9 +9,8 @@ namespace Mollie\Payment\Api\Webapi;
 interface StartTransactionRequestInterface
 {
     /**
-     * @param string $cartId
-     * @param int $orderId
+     * @param string $token
      * @return string
      */
-    public function execute($token);
+    public function execute(string $token);
 }

--- a/Test/Integration/Webapi/AbstractWebApiTest.php
+++ b/Test/Integration/Webapi/AbstractWebApiTest.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ *  * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Test\Integration\Webapi;
+
+use Magento\Webapi\Model\Config\ClassReflector;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+abstract class AbstractWebApiTest extends IntegrationTestCase
+{
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var string[]
+     */
+    protected $methods;
+
+    public function testValidatesForSwagger()
+    {
+        if (!$this->class || !$this->methods) {
+            throw new \Exception('Please set the $class and $method variables');
+        }
+
+        /** @var ClassReflector $reflector */
+        $reflector = $this->objectManager->get(ClassReflector::class);
+
+        $implementations = array_merge([$this->class], class_implements($this->class));
+        foreach ($implementations as $implementation) {
+            $reflector->reflectClassMethods($implementation, $this->methods);
+            $this->addToAssertionCount(1);
+        }
+    }
+}

--- a/Test/Integration/Webapi/GetCustomerOrderTest.php
+++ b/Test/Integration/Webapi/GetCustomerOrderTest.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ *  * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Webapi;
+
+use Mollie\Payment\Test\Integration\Webapi\AbstractWebApiTest;
+
+class GetCustomerOrderTest extends AbstractWebApiTest
+{
+    /**
+     * @var string
+     */
+    protected $class = GetCustomerOrder::class;
+
+    /**
+     * @var string[]
+     */
+    protected $methods = ['byHash'];
+}

--- a/Test/Integration/Webapi/PaymentTokenTest.php
+++ b/Test/Integration/Webapi/PaymentTokenTest.php
@@ -9,9 +9,20 @@ namespace Mollie\Payment\Webapi;
 use Magento\Quote\Model\Quote;
 use Mollie\Payment\Api\PaymentTokenRepositoryInterface;
 use Mollie\Payment\Test\Integration\IntegrationTestCase;
+use Mollie\Payment\Test\Integration\Webapi\AbstractWebApiTest;
 
-class PaymentTokenTest extends IntegrationTestCase
+class PaymentTokenTest extends AbstractWebApiTest
 {
+    /**
+     * @var string
+     */
+    protected $class = PaymentToken::class;
+
+    /**
+     * @var string
+     */
+    protected $methods = ['byToken', 'generateForCustomer', 'generateForGuest'];
+
     /**
      * @magentoDataFixture Magento/Sales/_files/quote.php
      */

--- a/Test/Integration/Webapi/StartTransactionTest.php
+++ b/Test/Integration/Webapi/StartTransactionTest.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ *  * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Webapi;
+
+use Mollie\Payment\Test\Integration\Webapi\AbstractWebApiTest;
+
+class StartTransactionTest extends AbstractWebApiTest
+{
+    /**
+     * @var string
+     */
+    protected $class = StartTransaction::class;
+
+    protected $methods = ['execute'];
+}

--- a/Webapi/GetCustomerOrder.php
+++ b/Webapi/GetCustomerOrder.php
@@ -30,6 +30,11 @@ class GetCustomerOrder implements GetCustomerOrderInterface
         $this->orderRepository = $orderRepository;
     }
 
+    /**
+     * @param string $hash
+     * @return mixed[]
+     * @throws \Exception
+     */
     public function byHash(string $hash): array
     {
         $decodedHash = base64_decode($hash);

--- a/Webapi/PaymentToken.php
+++ b/Webapi/PaymentToken.php
@@ -39,6 +39,10 @@ class PaymentToken implements PaymentTokenRequestInterface
         $this->paymentToken = $paymentToken;
     }
 
+    /**
+     * @param CartInterface $cart
+     * @return string
+     */
     public function generate(CartInterface $cart)
     {
         $token = $this->paymentToken->forCart($cart);
@@ -46,6 +50,11 @@ class PaymentToken implements PaymentTokenRequestInterface
         return $token;
     }
 
+    /**
+     * @param string $cartId
+     * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
     public function generateForCustomer($cartId)
     {
         $cart = $this->cartRepository->get($cartId);
@@ -53,6 +62,11 @@ class PaymentToken implements PaymentTokenRequestInterface
         return $this->generate($cart);
     }
 
+    /**
+     * @param string $cartId
+     * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
     public function generateForGuest($cartId)
     {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');

--- a/Webapi/StartTransaction.php
+++ b/Webapi/StartTransaction.php
@@ -32,12 +32,12 @@ class StartTransaction implements StartTransactionRequestInterface
     }
 
     /**
-     * @param $token
+     * @param string $token
      * @return string
      * @throws LocalizedException
      * @throws \Mollie\Api\Exceptions\ApiException
      */
-    public function execute($token)
+    public function execute(string $token)
     {
         $model = $this->paymentTokenRepository->getByToken($token);
         $order = $this->orderRepository->get($model->getOrderId());


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [X] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [X] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
- [X] Rest API

**Please describe the bug/feature/etc this PR contains:**

Open this URL, it fails:
```
{{URL}}/default/rest/all/schema?services=all
```