### PR TITLE
test: add typed return type void to setUp() methods

### DIFF
--- a/Test/Integration/Controller/Checkout/RedirectTest.php
+++ b/Test/Integration/Controller/Checkout/RedirectTest.php
@@ -17,7 +17,7 @@ use Mollie\Payment\Test\Fakes\Model\Methods\IdealFake;
 
 class RedirectTest extends ControllerTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/GraphQL/Resolver/Checkout/PaymentTokenTest.php
+++ b/Test/Integration/GraphQL/Resolver/Checkout/PaymentTokenTest.php
@@ -15,7 +15,7 @@ use Mollie\Payment\Test\Integration\IntegrationTestCase;
 
 class PaymentTokenTest extends IntegrationTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Integration/IntegrationTestCase.php
+++ b/Test/Integration/IntegrationTestCase.php
@@ -16,7 +16,7 @@ class IntegrationTestCase extends TestCase
      */
     protected $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = ObjectManager::getInstance();
     }

--- a/Test/Integration/Service/Order/Lines/StoreCreditTest.php
+++ b/Test/Integration/Service/Order/Lines/StoreCreditTest.php
@@ -15,7 +15,7 @@ class StoreCreditTest extends TestCase
      */
     private $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = ObjectManager::getInstance();
     }

--- a/Test/Integration/Setup/SchemaTest.php
+++ b/Test/Integration/Setup/SchemaTest.php
@@ -13,7 +13,7 @@ class SchemaTest extends TestCase
      */
     private $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = ObjectManager::getInstance();
     }

--- a/Test/Unit/Helper/GeneralTest.php
+++ b/Test/Unit/Helper/GeneralTest.php
@@ -20,7 +20,7 @@ class GeneralTest extends TestCase
      */
     private $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
     }

--- a/Test/Unit/Model/Methods/AbstractMethodTest.php
+++ b/Test/Unit/Model/Methods/AbstractMethodTest.php
@@ -33,7 +33,7 @@ abstract class AbstractMethodTest extends TestCase
      */
     protected $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
     }

--- a/Test/Unit/Plugin/Framework/App/Request/CsrfValidatorSkipTest.php
+++ b/Test/Unit/Plugin/Framework/App/Request/CsrfValidatorSkipTest.php
@@ -9,7 +9,7 @@ use Mollie\Payment\Test\Unit\UnitTestCase;
 
 class CsrfValidatorSkipTest extends UnitTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Unit/Service/Mollie/Order/RefundUsingPaymentTest.php
+++ b/Test/Unit/Service/Mollie/Order/RefundUsingPaymentTest.php
@@ -29,7 +29,7 @@ class RefundUsingPaymentTest extends TestCase
      */
     private $instance;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
 

--- a/Test/Unit/Service/Order/ProcessAdjustmentFeeTest.php
+++ b/Test/Unit/Service/Order/ProcessAdjustmentFeeTest.php
@@ -32,7 +32,7 @@ class ProcessAdjustmentFeeTest extends TestCase
      */
     private $refundUsingPaymentMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Test/Unit/UnitTestCase.php
+++ b/Test/Unit/UnitTestCase.php
@@ -12,7 +12,7 @@ class UnitTestCase extends TestCase
      */
     protected $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
     }


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:` **not applicable**
- [ ] Contains tests for the changed/added code (great if so but not required).  **not applicable**
- [ ] I have added a scenario to test my changes.  **not applicable**

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
Replaced `protected function setUp()` with `protected function setUp(): void` to match the parent declaration of PHPUnit tests to resolve the error as described in https://github.com/mollie/magento2/issues/292

**Please describe the bug/feature/etc this PR contains:**

See https://github.com/mollie/magento2/issues/292

**Scenario to test this code:**

Execute integration tests with the default phpunit.xml.dist file,