### PR TITLE
Fixed '.min.js' addition to mollie.js

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -256,5 +256,12 @@
                 <mollie_payment_fee>25</mollie_payment_fee>
             </totals_sort>
         </sales>
+        <dev>
+            <js>
+                <minify_exclude>
+                    <mollie>https://js.mollie.com/v1/mollie.js</mollie>
+                </minify_exclude>
+            </js>
+        </dev>
     </default>
 </config>


### PR DESCRIPTION
In the checkout the creditcard component will break when minify JS is on in Magento due to being an ".min" added to the URL. By excluding the file in the config.xml, this is fixed.

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When minification in Magento is on, it will add '.min.js' to files. This breaks external files, like the one requested in https://github.com/mollie/magento2/blob/master/view/frontend/web/js/view/payment/method-renderer/creditcard-with-components.js (https://js.mollie.com/v1/mollie.js).

By specifically excluding this file in the config.xml, this fixes it.

**Scenario to test this code:**

Have the Magento Minify JS feature on and go to the checkout while creditcards are on. It now works.