### PR TITLE
Fix second chance disabled setting

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -199,6 +199,9 @@ class Config
      */
     public function automaticallySendSecondChanceEmails($storeId = null)
     {
+        if (!$this->isSecondChanceEmailEnabled($storeId)) {
+            return false;
+        }
         return $this->isSetFlag(static::GENERAL_AUTOMATICALLY_SEND_SECOND_CHANCE_EMAILS, $storeId);
     }
 


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [x] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [x] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Please describe the bug/feature/etc this PR contains:**
When 'Enable second chance email' is disabled, but 'Automatically send second chance emails' is still enabled via the Magento 2 admin (an input mistake that is easily made by the store manager), reminder emails are still being send via cron.

![ Magento Admin 2020-11-13 09-53-29](https://user-images.githubusercontent.com/14849044/99048826-59fce480-2596-11eb-959c-2175442ec243.png)

**Scenario to test this code:**
Check `\Mollie\Payment\Test\Integration\Controller\Checkout\SecondChanceTest::testSecondChanceDisabledAutoSendEnabled`