### PR TITLE
[FIX] Adding svg to addQrOption

### DIFF
--- a/Model/Mollie.php
+++ b/Model/Mollie.php
@@ -616,7 +616,7 @@ class Mollie extends AbstractMethod
                 'resource' => 'issuer',
                 'id'       => '',
                 'name'     => __('QR Code'),
-                'image'    => ['size2x' => $this->assetRepository->getUrl("Mollie_Payment::images/qr-select.png")]
+                'image'    => ['size2x' => $this->assetRepository->getUrl("Mollie_Payment::images/qr-select.png"), 'svg' => $this->assetRepository->getUrl("Mollie_Payment::images/qr-select.svg")]
             ];
         }
 


### PR DESCRIPTION
Fixes #322  

**Svg should also be added, but this  at least makes the GraphQL call work again.**

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [x] Payment methods