### PR TITLE
Fixes for ACL

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,14 +6,14 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Mollie_Payment::config" title="Mollie configuration"/>
+                            <resource id="Mollie_Payment::config" title="Mollie Configuration" translate="title" />
                         </resource>
                     </resource>
                 </resource>
-                <resource id="Magento_Sales::sales" title="Sales" translate="title" sortOrder="20">
-                    <resource id="Mollie_Payment::payment_reminders" title="Mollie payment reminders">
-                        <resource id="Mollie_Payment::pending_payment_reminders" title="Mollie pending payment reminders" />
-                        <resource id="Mollie_Payment::sent_payment_reminders" title="Mollie sent payment reminders" />
+                <resource id="Magento_Sales::sales">
+                    <resource id="Mollie_Payment::payment_reminders" title="Mollie Payment Reminders" translate="title">
+                        <resource id="Mollie_Payment::pending_payment_reminders" title="Pending Payment Reminders"  translate="title" />
+                        <resource id="Mollie_Payment::sent_payment_reminders" title="Sent Payment Reminders" translate="title" />
                     </resource>
                 </resource>
             </resource>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
         <add id="Mollie_Payment::payment_reminders" title="Mollie Payment Reminders" translate="title" module="Mollie_Payment" sortOrder="10" parent="Magento_Sales::sales" resource="Mollie_Payment::payment_reminders" />
-        <add id="Mollie_Payment::pending_payment_reminders" title="Pending" translate="title" module="Magento_Sales" sortOrder="10" parent="Mollie_Payment::payment_reminders" action="mollie/reminder/pending" resource="Mollie_Payment::pending_payment_reminders"/>
-        <add id="Mollie_Payment::sent_payment_reminders" title="Sent" translate="title" module="Magento_Sales" sortOrder="20" parent="Mollie_Payment::payment_reminders" action="mollie/reminder/sent" resource="Mollie_Payment::sent_payment_reminders"/>
+        <add id="Mollie_Payment::pending_payment_reminders" title="Pending" translate="title" module="Mollie_Payment" sortOrder="10" parent="Mollie_Payment::payment_reminders" action="mollie/reminder/pending" resource="Mollie_Payment::pending_payment_reminders"/>
+        <add id="Mollie_Payment::sent_payment_reminders" title="Sent" translate="title" module="Mollie_Payment" sortOrder="20" parent="Mollie_Payment::payment_reminders" action="mollie/reminder/sent" resource="Mollie_Payment::sent_payment_reminders"/>
     </menu>
 </config>


### PR DESCRIPTION
 - No change definition for Magento_Sales:sales
- Fixed titles for consistent view
- Added translatable for ACL titles
- Set proper module name for Menu items
