### PR TITLE
compatible: afterPlaceOrder super gets called so other modules can use the function

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/default.js
+++ b/view/frontend/web/js/view/payment/method-renderer/default.js
@@ -81,6 +81,7 @@ define(
                     return promise;
                 },
                 afterPlaceOrder: function () {
+                    this._super();
                     window.location = url.build('mollie/checkout/redirect/paymentToken/' + this.paymentToken());
                 }
             }


### PR DESCRIPTION
- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

We encountered a problem in the Mollie module which causes the following issue: 
https://github.com/danslo/CleanCheckout/issues/91#issuecomment-757833549

The clean checkout module uses the afterPlaceOrder method. Mollie breaks that functionality currently. 

**Scenario to test this code:**

Open the environment and place a console.log or debugger in the magento/module-checkout/view/frontend/web/js/view/payment/default.js file in the afterPlaceOrder method. This now gets called as well as the Mollie overwrite.


