### PR TITLE
Delete Payment Reminders for guest users by email and for loggedin by customer id

### DIFF
--- a/Observer/MollieProcessTransactionEnd/RemoveCompletedOrdersFromPendingPaymentTable.php
+++ b/Observer/MollieProcessTransactionEnd/RemoveCompletedOrdersFromPendingPaymentTable.php
@@ -46,7 +46,6 @@ class RemoveCompletedOrdersFromPendingPaymentTable implements ObserverInterface
             return;
         }
 
-        $email = $order->getCustomerEmail();
-        $this->deletePaymentReminder->byEmail($email);
+        $this->deletePaymentReminder->delete($order->getCustomerId() ?: $order->getCustomerEmail());
     }
 }

--- a/Observer/SalesOrderPlaceBefore/RemovePendingPaymentReminders.php
+++ b/Observer/SalesOrderPlaceBefore/RemovePendingPaymentReminders.php
@@ -49,6 +49,6 @@ class RemovePendingPaymentReminders implements ObserverInterface
             return;
         }
 
-        $this->deletePaymentReminder->byEmail($email);
+        $this->deletePaymentReminder->delete($order->getCustomerId() ?: $order->getCustomerEmail());
     }
 }

--- a/Service/Order/PaymentReminder.php
+++ b/Service/Order/PaymentReminder.php
@@ -105,7 +105,7 @@ class PaymentReminder
 
         $this->sentPaymentReminderRepository->save($sent);
 
-        $this->deletePaymentReminder->byEmail($order->getCustomerEmail());
+        $this->deletePaymentReminder->delete($order->getCustomerId() ?: $order->getCustomerEmail());
     }
 
     private function isAlreadySend(OrderInterface $order): bool
@@ -113,7 +113,7 @@ class PaymentReminder
         try {
             // The next line throws an exception if the order does not exists
             $this->sentPaymentReminderRepository->getByOrderId($order->getEntityId());
-            $this->deletePaymentReminder->byEmail($order->getCustomerEmail());
+            $this->deletePaymentReminder->delete($order->getCustomerId() ?: $order->getCustomerEmail());
             return true;
         } catch (NoSuchEntityException $exception) {
             return false;


### PR DESCRIPTION
- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [x] Email sending

*Order Processing (Mollie communication)*
- [x] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
* Pyament Reminder

**Please describe the bug/feature/etc this PR contains:**

When you place an order the event "sales_order_place_before" is triggered an the method `\Mollie\Payment\Observer\SalesOrderPlaceBefore\RemovePendingPaymentReminders::execute` is being executed. This method wants to delete all payment reminders by email. The email address is fetched from the order and sent to `\Mollie\Payment\Service\Order\DeletePaymentReminder`. There we create a new order collection based on the filters `CREATED_AT` and `CUSTOMER_EMAIL`. Now you're retrieving all the orders with that email address regardless of the customer id (so you will get guest and logged in orders). 

Now when the collection is loaded and all the retrieved orders are being loaded the following plugin is executed after load `\Magento\Sales\Model\ResourceModel\Order\Plugin\Authorization::afterLoad`. This plugin checks if you're allowed to load the order.

```
/**
 * @param ResourceOrder $subject
 * @param ResourceOrder $result
 * @param \Magento\Framework\Model\AbstractModel $order
 * @return ResourceOrder
 * @throws NoSuchEntityException
 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 */
public function afterLoad(
    ResourceOrder $subject,
    ResourceOrder $result,
    \Magento\Framework\Model\AbstractModel $order
) {
    if ($order instanceof Order) {
        if (!$this->isAllowed($order)) {
            throw NoSuchEntityException::singleField('orderId', $order->getId());
        }
    }
    return $result;
}

/**
 * Checks if order is allowed for current customer
 *
 * @param \Magento\Sales\Model\Order $order
 * @return bool
 */
protected function isAllowed(Order $order)
{
    return $this->userContext->getUserType() == UserContextInterface::USER_TYPE_CUSTOMER
        ? $order->getCustomerId() == $this->userContext->getUserId()
        : true;
}
```

In our case if we have placed an order a guest. Then we want to place our next order as logged in customer. We will get an error that the order of the guest with customerId `null` is not the same as `$this->userContext->getUserId()`. Resulting in being unable to place the order.

**Scenario to test this code:**

* Place order as guest
* Place order as loggedin in customer with same email address as guest user
* Can't place order because we're not allowed to load the order of the guest user with the same email address