### PR TITLE
Display the error when fetching the payment status

### DIFF
--- a/view/adminhtml/web/js/order/fetch-order-status.js
+++ b/view/adminhtml/web/js/order/fetch-order-status.js
@@ -16,7 +16,12 @@ define([
                 method: 'POST',
                 data: {order_id: config.order_id},
                 success: function (result) {
-                    location.reload();
+                    if (result.error) {
+                        row.html('<th>' + $t('Error While Fetching') + '</th><td class="mollie-error">' + result.msg + '</td>');
+                        row.show();
+                    } else {
+                        location.reload();
+                    }
                 },
                 error: function (result) {
                     row.html('<th>' + $t('Error While Fetching') + '</th><td class="mollie-error">' + result.responseJSON.msg + '</td>');


### PR DESCRIPTION
POST returns 200 and has a JSON body which explains a possible error but this isn't shown to the user

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [x] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i was manually fetching the payment status nothing happened, apparently an error was occurring which wasn't being shown to the end user (me)

**Scenario to test this code:**

Open the environment and try to fetch the status of a payment which Mollie can't find (for example using the incorrect / an older API key which has no knowledge of this transaction ID)