### PR TITLE
Bugfix: Make sure orders get cancelled when they need to get cancelled

### DIFF
--- a/Controller/Checkout/Redirect.php
+++ b/Controller/Checkout/Redirect.php
@@ -13,6 +13,7 @@ use Magento\Payment\Model\MethodInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
 use Mollie\Payment\Api\PaymentTokenRepositoryInterface;
 use Mollie\Payment\Config;
 use Mollie\Payment\Helper\General as MollieHelper;
@@ -151,10 +152,6 @@ class Redirect extends Action
 
     private function cancelUnprocessedOrder(OrderInterface $order, $message)
     {
-        if (!empty($order->getMollieTransactionId())) {
-            return;
-        }
-
         if (!$this->config->cancelFailedOrders()) {
             return;
         }
@@ -165,6 +162,7 @@ class Redirect extends Action
                 $historyMessage .= ':<br>' . PHP_EOL . $message;
             }
 
+            $order->setState(Order::STATE_PENDING_PAYMENT);
             $this->orderManagement->cancel($order->getEntityId());
             $order->addCommentToStatusHistory($order->getEntityId(), $historyMessage);
 

--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -369,6 +369,7 @@ class Orders extends AbstractModel
             $msg = __('Created Mollie Checkout Url');
         }
 
+        $order->setState(Order::STATE_PENDING_PAYMENT);
         $order->addStatusToHistory($status, $msg, false);
         $order->setMollieTransactionId($mollieOrder->id);
         $this->orderRepository->save($order);

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -263,6 +263,7 @@ class Payments extends AbstractModel
 
         $status = $this->mollieHelper->getPendingPaymentStatus($order);
 
+        $order->setState(Order::STATE_PENDING_PAYMENT);
         $order->addStatusToHistory($status, __('Customer redirected to Mollie'), false);
         $order->setMollieTransactionId($payment->id);
         $this->orderRepository->save($order);

--- a/Service/Order/CancelOrder.php
+++ b/Service/Order/CancelOrder.php
@@ -11,6 +11,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\StatusResolver;
 use Magento\SalesRule\Model\Coupon;
 use Magento\SalesRule\Model\ResourceModel\Coupon\Usage;
 use Mollie\Payment\Config;
@@ -56,6 +57,11 @@ class CancelOrder
     private $couponUsage;
 
     /**
+     * @var StatusResolver
+     */
+    private $statusResolver;
+
+    /**
      * @var ResourceConnection
      */
     private $resource;
@@ -68,6 +74,7 @@ class CancelOrder
         OrderRepositoryInterface $orderRepository,
         Coupon $coupon,
         Usage $couponUsage,
+        StatusResolver $statusResolver,
         ResourceConnection $resource
     ) {
         $this->config = $config;
@@ -77,6 +84,7 @@ class CancelOrder
         $this->orderRepository = $orderRepository;
         $this->coupon = $coupon;
         $this->couponUsage = $couponUsage;
+        $this->statusResolver = $statusResolver;
         $this->resource = $resource;
     }
 
@@ -106,6 +114,7 @@ class CancelOrder
                 $comment = __('The order was canceled, reason: payment %1', $reason);
             }
 
+            $order->setStatus($this->statusResolver->getOrderStatusByState($order, Order::STATE_CANCELED));
             $this->config->addToLog('info', $order->getIncrementId() . ' ' . $comment);
             $this->orderCommentHistory->add($order, $comment);
             $order->getPayment()->setMessage($comment);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...