### PR TITLE
Allow graphql to listen to `payment/mollie_methods_ideal/issuer_list_type` configuration

### DIFF
--- a/Service/Mollie/GetIssuers.php
+++ b/Service/Mollie/GetIssuers.php
@@ -87,7 +87,7 @@ class GetIssuers
     {
         $mollieApi = $this->mollieModel->getMollieApi($storeId);
 
-	$issuers = $this->execute(
+        $issuers = $this->execute(
             $mollieApi,
             $method,
             $this->general->getIssuerListType($method)
@@ -100,7 +100,13 @@ class GetIssuers
         $output = [];
         foreach ($issuers as $issuer) {
             $issuer = (array)$issuer;
-            $issuer['image'] = (array)$issuer['image'];
+            if (!array_key_exists('image', $issuer)) {
+                $output[] = [
+                    'name' => $issuer['name'],
+                    'code' => $issuer['id']
+                ];
+                continue;
+            }
 
             $output[] = [
                 'name' => $issuer['name'],

--- a/Service/Mollie/GetIssuers.php
+++ b/Service/Mollie/GetIssuers.php
@@ -87,7 +87,12 @@ class GetIssuers
     {
         $mollieApi = $this->mollieModel->getMollieApi($storeId);
 
-        $issuers = $this->execute($mollieApi, $method, 'radio');
+	$issuers = $this->execute(
+            $mollieApi,
+            $method,
+            $this->general->getIssuerListType($method)
+        );
+
         if (!$issuers) {
             return null;
         }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -25,8 +25,8 @@ type SelectedPaymentMethod {
 type MollieIssuer {
     name: String
     code: String
-    image: String!
-    svg: String!
+    image: String
+    svg: String
 }
 
 type MolliePaymentMethodMeta {


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

Currently when the following configuration changes: `payment/mollie_methods_ideal/issuer_list_type` graphql endpoint keeps on returning the regular list with the images. I've adjusted `\Mollie\Payment\Service\Mollie\GetIssuers::getForGraphql` so that it also listens to the configuration value and returns the result accordingly.

I've had to loosen up the restrictions in the schema because when selecting dropdown, the very first option is the default `"-- Selecteer --"` value. Which doesn't have an image attached to it.

**Scenario to test this code:**

Perform the following graphql call when having some items in your cart on the Magento 2 instance.
```
query {
  cart(cart_id: "<YOUR_CART_ID>") {
    
    email
    id
    is_virtual
    total_quantity
  
    available_payment_methods {
      code
      title
      logo
      mollie_available_issuers {
        code
        image
        name
      }
    }
    selected_payment_method {
      code
      title
    }
  }
}
```

It should comply with the configuration and show the `mollie_available_issuers` accordingly.