### PR TITLE
add event dispatch to have option to manipulate mollie order data in …

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -7,6 +7,7 @@
 namespace Mollie\Payment\Model\Client;
 
 use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Exception\LocalizedException;
@@ -305,6 +306,13 @@ class Orders extends AbstractModel
         if ($this->expires->availableForMethod($method, $storeId)) {
             $orderData['expiresAt'] = $this->expires->atDateForMethod($method, $storeId);
         }
+
+        $eventData = [
+            'order' => $order,
+            'order_data' => new DataObject($orderData)
+        ];
+        $this->eventManager->dispatch('mollie_before_build_transaction_orders_api', $eventData);
+        $orderData = $eventData['order_data']->toArray();
 
         $orderData = $this->buildTransaction->execute($order, static::CHECKOUT_TYPE, $orderData);
 


### PR DESCRIPTION
…3rd party code

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [x] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

In our company we implement a project in which an additional payment is added to the order under certain conditions.

The problem arises for Klarna payment, when this extra payment is added, the order amounts do not match. 

One possible solution is to add an event that will be called before the `buildTransaction`, which will allow the custom payment to be added to the `orderData`.
