### PR TITLE
Add compatibility for Fooman Order Fees

### DIFF
--- a/Service/Order/Lines/Generator/FoomanTotals.php
+++ b/Service/Order/Lines/Generator/FoomanTotals.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Service\Order\Lines\Generator;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Framework\Module\Manager;
+use Mollie\Payment\Helper\General;
+
+class FoomanTotals implements GeneratorInterface
+{
+    /**
+     * @var General
+     */
+    private $mollieHelper;
+
+    /**
+     * @var Manager
+     */
+    private $moduleManager;
+
+    public function __construct(
+        General $mollieHelper,
+        Manager $moduleManager
+    ) {
+        $this->mollieHelper = $mollieHelper;
+        $this->moduleManager = $moduleManager;
+    }
+
+    public function process(OrderInterface $order, array $orderLines): array
+    {
+        if (!$this->moduleManager->isEnabled('Fooman_Totals')) {
+            return $orderLines;
+        }
+
+        $extAttr = $order->getExtensionAttributes();
+        if (!$extAttr) {
+            return $orderLines;
+        }
+
+        $foomanGroup = $extAttr->getFoomanTotalGroup();
+        if (empty($foomanGroup)) {
+            return $orderLines;
+        }
+
+        $totals = $foomanGroup->getItems();
+        if (empty($totals)) {
+            return $orderLines;
+        }
+
+        $forceBaseCurrency = (bool)$this->mollieHelper->useBaseCurrency($order->getStoreId());
+        $currency = $forceBaseCurrency ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
+
+        foreach ($totals as $total) {
+            $amount = $forceBaseCurrency ? $total->getBaseAmount() : $total->getAmount();
+            $taxAmount = $forceBaseCurrency ? $total->getBaseTaxAmount() : $total->getTaxAmount();
+
+            $vatRate = 0;
+            if ($taxAmount) {
+                $vatRate = round(($taxAmount / $amount) * 100, 2);
+            }
+            $orderLines[] = [
+                'type' => 'surcharge',
+                'name' =>  $total->getLabel(),
+                'quantity' => 1,
+                'unitPrice' => $this->mollieHelper->getAmountArray($currency, $amount + $taxAmount),
+                'totalAmount' => $this->mollieHelper->getAmountArray($currency, $amount + $taxAmount),
+                'vatRate' => $vatRate,
+                'vatAmount' => $this->mollieHelper->getAmountArray($currency, $taxAmount)
+            ];
+        }
+
+        return $orderLines;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -125,6 +125,7 @@
     <type name="Mollie\Payment\Service\Order\Lines\OrderLinesGenerator">
         <arguments>
             <argument name="generators" xsi:type="array">
+                <item name="fooman_totals" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\FoomanTotals</item>
                 <item name="weee_fee" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\WeeeFeeGenerator</item>
                 <item name="mageworx_rewardpoints" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\MageWorxRewardPoints</item>
                 <item name="amasty_extrafee" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\AmastyExtraFee</item>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [x] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

This PR fixes the issue https://github.com/mollie/magento2/issues/512 we had when customers were trying to checkout with Klarna Pay Later or Klarna Slice It and had a Fooman Order Fee applied. All credits to @fooman for creating this patch.

**Scenario to test this code:**

Open the environment and a custom option added by the Fooman Order Fees module. Checkout with one of the Klarna Pay Later methods.