### PR TITLE
Replace `success` with `done` function for jQuery 3.6 in M2.4.4

### DIFF
--- a/view/frontend/web/js/model/payment-token.js
+++ b/view/frontend/web/js/model/payment-token.js
@@ -36,7 +36,7 @@ define([
 
             var promise = storage.get(serviceUrl);
 
-            promise.success( function (result) {
+            promise.done( function (result) {
                 this.paymentToken = result;
             }.bind(this));
 

--- a/view/frontend/web/js/view/payment/method-renderer/default.js
+++ b/view/frontend/web/js/view/payment/method-renderer/default.js
@@ -74,7 +74,7 @@ define(
 
                     var promise = storage.get(serviceUrl);
 
-                    promise.success( function (result) {
+                    promise.done( function (result) {
                         this.paymentToken(result);
                     }.bind(this));
 


### PR DESCRIPTION
**This PR touches code in the following areas:**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [ ] Payment methods

**Please describe the bug/feature/etc this PR contains:**

- Install Magento 2.4.4 with latest mollie payment module
- Try placing an order (eg with iDEAL)
- Exception: `promise.success is not a function`

Magento 2.4.4 upgraded jQuery to 3.6, removing the deprecated `success` function on the jqXHR response. `done` should be used in `payment-token.js`


**Scenario to test this code:**

- Try placing an order (eg with iDEAL)
- You should be redirected to bank