### PR TITLE
Utilise ObjectManagerInterface instead of ObjectManager

### DIFF
--- a/Service/Order/Uncancel/OrderReservation.php
+++ b/Service/Order/Uncancel/OrderReservation.php
@@ -3,7 +3,7 @@
 namespace Mollie\Payment\Service\Order\Uncancel;
 
 use Magento\Catalog\Model\Indexer\Product\Price\Processor;
-use Magento\Framework\App\ObjectManager;
+use Magento\Framework\ObjectManagerInterface;
 use Magento\InventorySales\Model\SalesEvent;
 use Magento\InventorySalesApi\Api\Data\ItemToSellInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
@@ -45,7 +45,7 @@ class OrderReservation
     public function __construct(
         WebsiteRepositoryInterface $websiteRepository,
         Processor $priceIndexer,
-        ObjectManager $objectManager
+        ObjectManagerInterface $objectManager
     ) {
         $this->websiteRepository = $websiteRepository;
         $this->priceIndexer = $priceIndexer;


### PR DESCRIPTION
Using ObjectManager directly causes exceptions in the objectmanager while uncanceling orders.
Using ObjectManagerInterface instead fixes all of these problems, in the rest of this project the interface is already used.

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [x] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When updating the order status of a canceled order with payment method Sepa Bank Transfer which has been paid an exception will be thrown while uncancelling the order.

**Scenario to test this code:**

Open the environment and...