### PR TITLE
jQuery 3.0.x compatibility

### DIFF
--- a/view/frontend/web/js/view/checkout/save-payment-method.js
+++ b/view/frontend/web/js/view/checkout/save-payment-method.js
@@ -87,7 +87,7 @@ define([
             ).done( function () {
                 reloadTotals([]);
                 totals.isLoading(false);
-            }).error( function () {
+            }).fail( function () {
                 totals.isLoading(false);
             });
         }


### PR DESCRIPTION
This fix adds compatibility to jQuery 3.0. `error()` has been removed since jQuery 3.0. Since Magento 2.4.4 uses jQuery 3.0, this should be changed.

**jQuery post documentation:**
https://api.jquery.com/jquery.post/

**Magento's jQuery version file:**
https://github.com/magento/magento2/blob/2.4.4/lib/web/jquery/jquery.min.js