### PR TITLE
Return 200 OK on IDs not known in the system

### DIFF
--- a/Controller/Checkout/Webhook.php
+++ b/Controller/Checkout/Webhook.php
@@ -70,16 +70,13 @@ class Webhook extends Action
 
         $transactionId = $this->getRequest()->getParam('id');
         if (!$transactionId) {
-            return $this->getErrorResponse(404, __('No transaction ID found')->render());
+            return $this->getOkResponse();
         }
 
         try {
             $orderIds = $this->mollieModel->getOrderIdsByTransactionId($transactionId);
             if (!$orderIds) {
-                return $this->getErrorResponse(
-                    404,
-                    __('There is no order found that belongs to "%1"', $transactionId)->render()
-                );
+                return $this->getOkResponse();
             }
 
             foreach ($orderIds as $orderId) {


### PR DESCRIPTION
This PR touches code in the Webhook.

When the webhook is called with an ID which is not in the backend, it returns a 404 HTTP status code. This reveals that the ID of that transaction does not belong to the merchant. As stated in the [Mollie docs](https://docs.mollie.com/overview/webhooks):

"To not leak any information to malicious third parties, it is recommended to return a 200 OK response even if the ID is not known to your system."

Because of this, I have deleted the lines of code which returns anything but a 200 OK response, and instead used the method getOkResponse() to return a 200 OK, on transactions and orders which are not found in the backend. Checked a few other integrations and they seem to do this properly (always return 200 OK).

**Scenario to test this code:**

Once installed, call the webhook of the webshop with any transaction/order id. The webhook should return a 200 OK even if the transaction is not in the backend.

From Mollie TS <3