### PR TITLE
check if Order item is virtual instead of check order item product type

### DIFF
--- a/Service/Order/Lines/Order.php
+++ b/Service/Order/Lines/Order.php
@@ -173,7 +173,7 @@ class Order
 
         $orderLine = [
             'item_id' => $item->getId(),
-            'type' => !$item->getIsVirtual() ? 'physical' : 'digital',
+            'type' => $item->getIsVirtual() !== null && (int) $item->getIsVirtual() !== 1 ? 'physical' : 'digital',
             'name' => preg_replace('/[^A-Za-z0-9 -]/', '', $item->getName() ?? ''),
             'quantity' => round($item->getQtyOrdered()),
             'unitPrice' => $this->mollieHelper->getAmountArray($this->currency, $unitPrice),

--- a/Service/Order/Lines/Order.php
+++ b/Service/Order/Lines/Order.php
@@ -173,7 +173,7 @@ class Order
 
         $orderLine = [
             'item_id' => $item->getId(),
-            'type' => $item->getProductType() != 'downloadable' ? 'physical' : 'digital',
+            'type' => !$item->getIsVirtual() ? 'physical' : 'digital',
             'name' => preg_replace('/[^A-Za-z0-9 -]/', '', $item->getName() ?? ''),
             'quantity' => round($item->getQtyOrdered()),
             'unitPrice' => $this->mollieHelper->getAmountArray($this->currency, $unitPrice),


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [x] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.
Fix for #590 

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...