### PR TITLE
Fix for coupon code api requests

### DIFF
--- a/Plugin/Sales/Cart/AddPaymentFeeToCart.php
+++ b/Plugin/Sales/Cart/AddPaymentFeeToCart.php
@@ -34,6 +34,8 @@ class AddPaymentFeeToCart
     public function afterGetList(CartRepositoryInterface $subject, SearchResultsInterface $result)
     {
         $items = $result->getItems();
+        $items = array_filter($items, fn($item) => $item);
+
         foreach ($items as $id => $item) {
             $items[$id] = $this->processCart($item);
         }


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x ] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [x] Shopping cart
- [x] Checkout
- [x] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Please describe the bug/feature/etc this PR contains:**

We're using the magento api to apply coupon codes, when using a coupon code valid or invalid, this extension throws the following error: 
```TypeError: Mollie\Payment\Plugin\Sales\Cart\AddPaymentFeeToCart::processCart(): Argument #1 ($cart) must be of type Magento\Quote\Api\Data\CartInterface, null given,```

This error is thrown because the cartInterface is null. These changes fixes this.

**Scenario to test this code:**

Use a coupon code via api endpoints.