### PR TITLE
New Payment IDs breaks the module

### DIFF
--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -221,7 +221,7 @@ class Payments extends AbstractModel
         $orderId = $order->getEntityId();
 
         $transactionId = $order->getMollieTransactionId();
-        if (!empty($transactionId) && !preg_match('/^ord_\w+$/', $transactionId)) {
+        if (!empty($transactionId) && !preg_match('/^ord_(\d\.)?\w+$/', $transactionId)) {
             $payment = $mollieApi->payments->get($transactionId);
             return $payment->getCheckoutUrl();
         }

--- a/Model/Mollie.php
+++ b/Model/Mollie.php
@@ -360,7 +360,7 @@ class Mollie extends Adapter
             $type,
             $paymentToken
         ) {
-            if (preg_match('/^ord_\w+$/', $transactionId)) {
+            if (preg_match('/^ord_(\d\.)?\w+$/', $transactionId)) {
                 $result = $this->ordersProcessTraction->execute($order, $type)->toArray();
             } else {
                 $mollieApi = $this->mollieApiClient->loadByStore($order->getStoreId());
@@ -398,7 +398,7 @@ class Mollie extends Adapter
 
         $mollieApi = $this->mollieApiClient->loadByStore($order->getStoreId());
 
-        if (preg_match('/^ord_\w+$/', $transactionId)) {
+        if (preg_match('/^ord_(\d\.)?\w+$/', $transactionId)) {
             return $this->ordersApi->orderHasUpdate($order, $mollieApi);
         } else {
             return $this->paymentsApi->orderHasUpdate($order, $mollieApi);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [x] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [x] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [x] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Please describe the bug/feature/etc this PR contains:**
Fixes: #669