### PR TITLE
Prevent opening success page multiple times

### DIFF
--- a/Api/TransactionToOrderRepositoryInterface.php
+++ b/Api/TransactionToOrderRepositoryInterface.php
@@ -16,6 +16,8 @@ interface TransactionToOrderRepositoryInterface
      */
     public function get(int $id): \Mollie\Payment\Api\Data\TransactionToOrderInterface;
 
+    public function getByTransactionId(string $transactionId): TransactionToOrderInterface;
+
     /**
       * @param \Magento\Framework\Api\SearchCriteriaInterface $criteria
       * @return \Mollie\Payment\Api\Data\TransactionToOrderSearchResultsInterface

--- a/Model/TransactionToOrderRepository.php
+++ b/Model/TransactionToOrderRepository.php
@@ -93,6 +93,16 @@ class TransactionToOrderRepository implements TransactionToOrderRepositoryInterf
         return $transactionToOrder->getDataModel();
     }
 
+    public function getByTransactionId(string $transactionId): TransactionToOrderInterface
+    {
+        $transactionToOrder = $this->transactionToOrderFactory->create();
+        $this->resource->load($transactionToOrder, $transactionId, 'transaction_id');
+        if (!$transactionToOrder->getId()) {
+            throw new NoSuchEntityException(__('TransactionToOrder with transaction_id "%1" does not exist.', $transactionId));
+        }
+        return $transactionToOrder;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [x] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [x] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

Fix for https://github.com/mollie/magento2/issues/687

The idea is to check if the payment was already processed. If true, it makes no sense to reset checkout session data.

**Scenario to test this code:**

Open the environment and...