### PR TITLE
Check if the Payment Fee is available before calculating

### DIFF
--- a/Plugin/Tax/Helper/Data.php
+++ b/Plugin/Tax/Helper/Data.php
@@ -58,10 +58,20 @@ class Data
         $this->result = $result;
 
         $order = $source->getOrder();
+        if (!$order->getPayment() ||
+            strstr($order->getPayment()->getMethod(), 'mollie_methods_') === false
+        ) {
+            return $result;
+        }
+
         $amount = $order->getMolliePaymentFee();
         $taxAmount = $order->getMolliePaymentFeeTax();
         $baseTaxAmount = $order->getMolliePaymentFee();
-        $rate = round(($taxAmount / $amount) * 100);
+
+        $rate = 0;
+        if ((float)$order->getMolliePaymentFeeTax()) {
+            $rate = round(($taxAmount / $amount) * 100);
+        }
 
         $taxClassId = $this->config->paymentSurchargeTaxClass(
             $order->getPayment()->getMethod(),


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...