### PR TITLE
Resolve delivery methods issue on Apple Pay

### DIFF
--- a/Controller/ApplePay/ShippingMethods.php
+++ b/Controller/ApplePay/ShippingMethods.php
@@ -6,6 +6,7 @@
 
 namespace Mollie\Payment\Controller\ApplePay;
 
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
@@ -33,16 +34,23 @@ class ShippingMethods extends Action
      */
     private $shippingMethodManagement;
 
+    /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
     public function __construct(
         Context $context,
         CartRepositoryInterface $cartRepository,
         ShippingMethodManagementInterface $shippingMethodManagement,
+        CheckoutSession $checkoutSession,
         GuestCartRepositoryInterface $guestCartRepository
     ) {
         parent::__construct($context);
         $this->shippingMethodManagement = $shippingMethodManagement;
         $this->guestCartRepository = $guestCartRepository;
         $this->cartRepository = $cartRepository;
+        $this->checkoutSession = $checkoutSession;
     }
 
     public function execute()

--- a/Controller/ApplePay/ShippingMethods.php
+++ b/Controller/ApplePay/ShippingMethods.php
@@ -12,6 +12,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\GuestCartRepositoryInterface;
+use Magento\Quote\Api\ShippingMethodManagementInterface;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Total as AddressTotal;
 
@@ -27,12 +28,19 @@ class ShippingMethods extends Action
      */
     private $guestCartRepository;
 
+    /**
+     * @var ShippingMethodManagementInterface
+     */
+    private $shippingMethodManagement;
+
     public function __construct(
         Context $context,
         CartRepositoryInterface $cartRepository,
+        ShippingMethodManagementInterface $shippingMethodManagement,
         GuestCartRepositoryInterface $guestCartRepository
     ) {
         parent::__construct($context);
+        $this->shippingMethodManagement = $shippingMethodManagement;
         $this->guestCartRepository = $guestCartRepository;
         $this->cartRepository = $cartRepository;
     }

--- a/Controller/ApplePay/ShippingMethods.php
+++ b/Controller/ApplePay/ShippingMethods.php
@@ -30,7 +30,7 @@ class ShippingMethods extends Action
     public function __construct(
         Context $context,
         CartRepositoryInterface $cartRepository,
-        GuestCartRepositoryInterface $guestCartRepository,
+        GuestCartRepositoryInterface $guestCartRepository
     ) {
         parent::__construct($context);
         $this->guestCartRepository = $guestCartRepository;


### PR DESCRIPTION
- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Please describe the bug/feature/etc this PR contains:**
Resolve issue where changing shipping method in ApplePay does not correctly update the quote, resulting in orders failing.

Simplify entire code to remove unrequired saves/collects that are adding to the problem.

Don't set a default shipping method - by the nature of this method a shipping method is always being passed in.


When I change delivery method within Apple Pay popup, it should show a new total in the window including the new shipping amount. Currently the total doesn't update. Apple Pay then authorises the amount without the shipping method, then when it gets requested the total with shipping method it fails resulting in an error.