### PR TITLE
BUGFIX - Fix issue where this.applePayPaymentToken may not be defined at checkout

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/applepay-direct.js
+++ b/view/frontend/web/js/view/payment/method-renderer/applepay-direct.js
@@ -2,6 +2,7 @@ define(
     [
         'jquery',
         'uiRegistry',
+        'ko',
         'Mollie_Payment/js/view/payment/method-renderer/default',
         'Magento_Checkout/js/model/totals',
         'mage/url',
@@ -11,6 +12,7 @@ define(
     function (
         $,
         uiRegistry,
+        ko,
         Component,
         totals,
         url,
@@ -28,6 +30,7 @@ define(
             defaults: {
                 template: 'Mollie_Payment/payment/applepay-direct',
                 isIosc: uiRegistry.has("checkout.iosc.ajax"),
+                applePayPaymentToken: ko.observable('')
             },
 
             initObservable: function () {


### PR DESCRIPTION
- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [X] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [X] Checkout
- [ ] Totals
- [X] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Please describe the bug/feature/etc this PR contains:**

When loading the payment methods on Safari or Apple Devices, when Apple Pay is enabled the following error may occur:

```
this.applePayPaymentToken() is not a function
```

Attached screenshot from Safari DevTools:
![image](https://github.com/mollie/magento2/assets/3777938/024a5022-7d2d-45c6-b7be-0f6557baa3f2)

When this occurs it blocks all Mollie Payment methods from being rendered, including Credit Cards. This problem occurs due to this.applePayPaymentToken() not being defined as an observable in the component's defaults on load.

**Scenario to test this code:**

1. Open environment on a Safari or Apple device supporting Apple Pay
2. Add product, go to checkout
3. Apple Pay should display