### PR TITLE
Handle NULL gift wrapping amount case

### DIFF
--- a/Service/Order/Lines/Generator/MagentoGiftWrapping.php
+++ b/Service/Order/Lines/Generator/MagentoGiftWrapping.php
@@ -38,7 +38,7 @@ class MagentoGiftWrapping implements GeneratorInterface
             $extensionAttributes->getGwItemsBasePriceInclTax() :
             $extensionAttributes->getGwItemsPriceInclTax();
 
-        if (abs($amount) < 0.01) {
+        if ($amount === null || abs($amount) < 0.01) {
             return $orderLines;
         }
 


### PR DESCRIPTION
Fixes deprecation notice and subsequent crash in Adobe Commerce Cloud

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [x] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When I tried to check out (in Adobe Commerce Cloud hosting), the process crashed with a deprecation notice.

**Scenario to test this code:**

Open the environment and check out without using gift wrapping.