### PR TITLE
[DOK-138] handle failed status

### DIFF
--- a/Controller/Checkout/Process.php
+++ b/Controller/Checkout/Process.php
@@ -179,7 +179,7 @@ class Process extends Action
         }
 
         try {
-            $order = $this->orderRepository->get(end($orderIds));
+            $order = $this->orderRepository->get(array_key_last($orderIds));
             $this->checkoutSession->setLastRealOrderId($order->getIncrementId());
         } catch (NoSuchEntityException $exception) {
             //


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ x] The code is working on a plain Magento 2 installation.
- [x ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [x ] Shopping cart
- [ x] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ x] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When customer goes to mollie side, select bankcontract and in test mode select "FAILED" status, press continue - redirect goes to magento and restore not the latest quote but one before latest
This is happen because structure of order_ids is
`id => token`
and end function grab token and try to find order
but we should grab latest order ID and not token

**Scenario to test this code:**

Open the environment and...