### PR TITLE
Release/2.40.1

### DIFF
--- a/.github/workflows/end-2-end-test.yml
+++ b/.github/workflows/end-2-end-test.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Start the Magento container
         run: |
           openssl req -x509 -newkey rsa:4096 -keyout .github/workflows/templates/nginx-proxy/magento.test.key -out .github/workflows/templates/nginx-proxy/magento.test.crt -days 365 -nodes -subj "/CN=magento.test" && \
-          docker-compose -f .github/workflows/templates/docker-compose.yml up -d
+          docker compose -f .github/workflows/templates/docker-compose.yml up -d
           # Get the URL from ngrok
-          docker-compose -f .github/workflows/templates/docker-compose.yml logs ngrok
+          docker compose -f .github/workflows/templates/docker-compose.yml logs ngrok
           MAGENTO_URL=$(docker exec magento-project-community-edition /bin/bash -c "curl -s ngrok:4040/api/tunnels |jq -r \".tunnels[0].public_url\"")
           echo "magento_url=$MAGENTO_URL" >> $GITHUB_ENV
 
@@ -118,9 +118,9 @@ jobs:
       - name: Dump docker-compose logs
         if: always()
         run: |
-          docker-compose -f .github/workflows/templates/docker-compose.yml logs magento > magento.log && \
-          docker-compose -f .github/workflows/templates/docker-compose.yml logs ngrok > ngrok.log && \
-          docker-compose -f .github/workflows/templates/docker-compose.yml logs e2e > e2e.log
+          docker compose -f .github/workflows/templates/docker-compose.yml logs magento > magento.log && \
+          docker compose -f .github/workflows/templates/docker-compose.yml logs ngrok > ngrok.log && \
+          docker compose -f .github/workflows/templates/docker-compose.yml logs e2e > e2e.log
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/Controller/ApplePay/PlaceOrder.php
+++ b/Controller/ApplePay/PlaceOrder.php
@@ -86,13 +86,16 @@ class PlaceOrder extends Action
 
         $cart->setCustomerEmail($this->getRequest()->getParam('shippingAddress')['emailAddress']);
 
-        $shippingAddress->setShippingMethod(
-            str_replace(
-                '__SPLIT__',
-                '_',
-                $this->getRequest()->getParam('shippingMethod')['identifier']
-            )
-        );
+        // Orders with digital products can't have a shipping method
+        if ($this->getRequest()->getParam('shippingMethod')) {
+            $shippingAddress->setShippingMethod(
+                str_replace(
+                    '__SPLIT__',
+                    '_',
+                    $this->getRequest()->getParam('shippingMethod')['identifier']
+                )
+            );
+        }
 
         $cart->setPaymentMethod('mollie_methods_applepay');
         $cart->setCustomerIsGuest(true);

--- a/Model/Client/Orders/Processors/SuccessfulPayment.php
+++ b/Model/Client/Orders/Processors/SuccessfulPayment.php
@@ -104,12 +104,12 @@ class SuccessfulPayment implements OrderProcessorInterface
     }
 
     /**
-     * @param OrderInterface|\Magento\Sales\Model\Order $order
+     * @param OrderInterface|MagentoOrder $order
      * @param MollieOrder $mollieOrder
      * @param string $type
      * @param ProcessTransactionResponse $response
-     * @throws \Magento\Framework\Exception\LocalizedException
      * @return ProcessTransactionResponse|null
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function process(OrderInterface $order, Order $mollieOrder, string $type, ProcessTransactionResponse $response): ?ProcessTransactionResponse
     {
@@ -173,7 +173,9 @@ class SuccessfulPayment implements OrderProcessorInterface
         $payment->setTransactionId($paymentId);
         $payment->setCurrencyCode($order->getBaseCurrencyCode());
 
-        if ($order->getState() != \Magento\Sales\Model\Order::STATE_PROCESSING && $mollieOrder->isPaid()) {
+        if (!in_array($order->getState(), [MagentoOrder::STATE_PROCESSING, MagentoOrder::STATE_COMPLETE]) &&
+            $mollieOrder->isPaid()
+        ) {
             $payment->setIsTransactionClosed(true);
             $payment->registerCaptureNotification($order->getBaseGrandTotal(), true);
         }
@@ -230,7 +232,7 @@ class SuccessfulPayment implements OrderProcessorInterface
     }
 
     /**
-     * @param OrderInterface|\Magento\Sales\Model\Order $order
+     * @param OrderInterface|MagentoOrder $order
      */
     protected function sendOrderEmails(OrderInterface $order): void
     {

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -406,7 +406,9 @@ class Payments extends AbstractModel
                             );
                         }
 
-                        $payment->registerCaptureNotification($order->getBaseGrandTotal(), true);
+                        if (!in_array($order->getState(), [Order::STATE_PROCESSING, Order::STATE_COMPLETE])) {
+                            $payment->registerCaptureNotification($order->getBaseGrandTotal(), true);
+                        }
                     }
 
                     $order->setState(Order::STATE_PROCESSING);

--- a/Service/Magento/PaymentLinkRedirect.php
+++ b/Service/Magento/PaymentLinkRedirect.php
@@ -75,7 +75,7 @@ class PaymentLinkRedirect
             ]);
         }
 
-        if ($this->isPaymentLinkExpired->execute($order) || !$order->canReorder()) {
+        if ($this->isPaymentLinkExpired->execute($order)) {
             return $this->paymentLinkRedirectResultFactory->create([
                 'redirectUrl' => null,
                 'isExpired' => true,

--- a/Service/Mollie/GetMollieStatusResult.php
+++ b/Service/Mollie/GetMollieStatusResult.php
@@ -50,6 +50,7 @@ class GetMollieStatusResult
             'pending',
             'paid',
             'authorized',
+            'shipping', // When having free or virtual products orders might go into shipping status real quick
             'completed', // Completed is mainly to support digital products
         ]);
     }

--- a/Service/Mollie/Order/IsPaymentLinkExpired.php
+++ b/Service/Mollie/Order/IsPaymentLinkExpired.php
@@ -57,7 +57,7 @@ class IsPaymentLinkExpired
     private function checkWithDefaultDate(OrderInterface $order): bool
     {
         $now = $this->timezone->scopeDate($order->getStoreId());
-        $orderDate = $this->timezone->scopeDate($order->getStoreId(), $order->getCreatedAt());
+        $orderDate = $this->timezone->scopeDate($order->getStoreId(), new \DateTime($order->getCreatedAt()));
         $diff = $now->diff($orderDate);
 
         return $diff->days >= 28;

--- a/Service/Order/MethodCode.php
+++ b/Service/Order/MethodCode.php
@@ -51,6 +51,7 @@ class MethodCode
         }
 
         if (!is_array($additionalInformation['limited_methods']) || count($additionalInformation['limited_methods']) !== 1) {
+            $this->expiresAtMethod = 'paymentlink';
             return '';
         }
 

--- a/Test/End-2-end/cypress/e2e/magento/checkout.cy.js
+++ b/Test/End-2-end/cypress/e2e/magento/checkout.cy.js
@@ -28,7 +28,7 @@ describe('Checkout usage', () => {
 
     const availableMethods = Cypress.env('mollie_available_methods');
     [
-      'alma',
+      // 'alma', Disabled, not available in NL
       'bancomatpay',
       'bancontact',
       'banktransfer',

--- a/Test/Integration/Service/Magento/PaymentLinkRedirectTest.php
+++ b/Test/Integration/Service/Magento/PaymentLinkRedirectTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Magento;
+
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Mollie\Payment\Model\Mollie;
+use Mollie\Payment\Service\Magento\PaymentLinkRedirect;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class PaymentLinkRedirectTest extends IntegrationTestCase
+{
+    public function testThrowsExceptionWhenOrderDoesNotExists(): void
+    {
+        $this->expectException(\Magento\Framework\Exception\NotFoundException::class);
+
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $orderId = base64_encode($encryptor->encrypt('random string'));
+
+        /** @var PaymentLinkRedirect $instance */
+        $instance = $this->objectManager->create(PaymentLinkRedirect::class);
+
+        $instance->execute($orderId);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     *
+     * @return void
+     */
+    public function testDoesNotRedirectWhenOrderAlreadyPaid(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->setState(Order::STATE_PROCESSING);
+
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $orderId = base64_encode($encryptor->encrypt($order->getEntityId()));
+
+        /** @var PaymentLinkRedirect $instance */
+        $instance = $this->objectManager->create(PaymentLinkRedirect::class);
+        $result = $instance->execute($orderId);
+
+        $this->assertTrue($result->isAlreadyPaid());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     *
+     * @return void
+     */
+    public function testDoesNotRedirectWhenExpired(): void
+    {
+        $orderRepository = $this->objectManager->get(OrderRepositoryInterface::class);
+
+        $order = $this->loadOrder('100000001');
+        $order->setState(Order::STATE_PENDING_PAYMENT);
+        $order->setCreatedAt(date('Y-m-d H:i:s', strtotime('-31 days')));
+        $orderRepository->save($order);
+
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+        $orderId = base64_encode($encryptor->encrypt($order->getEntityId()));
+
+        /** @var PaymentLinkRedirect $instance */
+        $instance = $this->objectManager->create(PaymentLinkRedirect::class);
+        $result = $instance->execute($orderId);
+
+        $this->assertTrue($result->isExpired());
+    }
+}

--- a/Test/Integration/Service/Mollie/Order/IsPaymentLinkExpiredTest.php
+++ b/Test/Integration/Service/Mollie/Order/IsPaymentLinkExpiredTest.php
@@ -25,7 +25,7 @@ class IsPaymentLinkExpiredTest extends IntegrationTestCase
 
         $date = new \DateTimeImmutable();
         $date = $date->add(new \DateInterval('P28D'))->setTime(0, 0, 0);
-        $order->setcreatedAt($date->format('Y-m-d H:i:s'));
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
 
         $instance = $this->objectManager->create(IsPaymentLinkExpired::class);
 
@@ -42,7 +42,7 @@ class IsPaymentLinkExpiredTest extends IntegrationTestCase
 
         $date = new \DateTimeImmutable();
         $date = $date->add(new \DateInterval('P29D'))->setTime(23, 59, 59);
-        $order->setcreatedAt($date->format('Y-m-d H:i:s'));
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
 
         $instance = $this->objectManager->create(IsPaymentLinkExpired::class);
 
@@ -61,7 +61,7 @@ class IsPaymentLinkExpiredTest extends IntegrationTestCase
 
         $date = new \DateTimeImmutable();
         $date = $date->add(new \DateInterval('P9D'))->setTime(0, 0, 0);
-        $order->setcreatedAt($date->format('Y-m-d H:i:s'));
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
 
         $order->getPayment()->setAdditionalInformation(['limited_methods' => ['ideal']]);
 
@@ -82,11 +82,36 @@ class IsPaymentLinkExpiredTest extends IntegrationTestCase
 
         $date = new \DateTimeImmutable();
         $date = $date->add(new \DateInterval('P11D'))->setTime(23, 59, 59);
-        $order->setcreatedAt($date->format('Y-m-d H:i:s'));
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
 
         $order->getPayment()->setAdditionalInformation(['limited_methods' => ['ideal']]);
 
         $instance = $this->objectManager->create(IsPaymentLinkExpired::class);
+
+        $this->assertTrue($instance->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_paymentlink/days_before_expire 10
+     */
+    public function testUsesPaymentlinkForExpiryWhenNoLimitedMethodsAreSet(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setMethod(Paymentlink::CODE);
+        $order->getPayment()->setAdditionalInformation(['limited_methods' => null]);
+
+        $instance = $this->objectManager->create(IsPaymentLinkExpired::class);
+
+        $date = new \DateTimeImmutable();
+        $date = $date->add(new \DateInterval('P9D'))->setTime(23, 59, 59);
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
+
+        $this->assertFalse($instance->execute($order));
+
+        $date = new \DateTimeImmutable();
+        $date = $date->add(new \DateInterval('P11D'))->setTime(23, 59, 59);
+        $order->setCreatedAt($date->format('Y-m-d H:i:s'));
 
         $this->assertTrue($instance->execute($order));
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mollie/magento2",
   "description": "Mollie Payment Module for Magento 2",
-  "version": "2.40.0",
+  "version": "2.40.1",
   "keywords": [
     "mollie",
     "payment",

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,7 +8,7 @@
     <default>
         <payment>
             <mollie_general>
-                <version>v2.40.0</version>
+                <version>v2.40.1</version>
                 <active>0</active>
                 <enabled>0</enabled>
                 <type>test</type>

--- a/view/adminhtml/templates/form/mollie_paymentlink_javascript.phtml
+++ b/view/adminhtml/templates/form/mollie_paymentlink_javascript.phtml
@@ -3,8 +3,12 @@
  * Copyright Magmodules.eu. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<script>
+
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<SCRIPT
     document.addEventListener('DOMContentLoaded', function () {
         const saveSelectedMethods = () => {
             // Save the selected payment methods to local storage
@@ -46,4 +50,6 @@
             setSelectedMethods();
         })
     });
-</script>
+SCRIPT;
+
+echo $secureRenderer->renderTag('script', [], $scriptString, false);

--- a/view/adminhtml/templates/form/mollie_paymentlink_javascript.phtml
+++ b/view/adminhtml/templates/form/mollie_paymentlink_javascript.phtml
@@ -8,29 +8,29 @@ use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /** @var SecureHtmlRenderer $secureRenderer */
 
-$scriptString = <<<SCRIPT
-    document.addEventListener('DOMContentLoaded', function () {
+$scriptString = '
+    document.addEventListener(\'DOMContentLoaded\', function () {
         const saveSelectedMethods = () => {
             // Save the selected payment methods to local storage
-            var paymentMethods = document.getElementById('mollie_methods_paymentlink_methods');
+            var paymentMethods = document.getElementById(\'mollie_methods_paymentlink_methods\');
             if (!paymentMethods) {
                 return;
             }
 
-            paymentMethods.addEventListener('change', function () {
+            paymentMethods.addEventListener(\'change\', function () {
                 var selected = [];
                 for (var i = 0; i < paymentMethods.options.length; i++) {
                     if (paymentMethods.options[i].selected) {
                         selected.push(paymentMethods.options[i].value);
                     }
                 }
-                localStorage.setItem('mollie_paymentlink_methods', JSON.stringify(selected));
+                localStorage.setItem(\'mollie_paymentlink_methods\', JSON.stringify(selected));
             });
         };
 
         const setSelectedMethods = () => {
-            var paymentMethods = document.getElementById('mollie_methods_paymentlink_methods');
-            const selectedMethods = JSON.parse(localStorage.getItem('mollie_paymentlink_methods'));
+            var paymentMethods = document.getElementById(\'mollie_methods_paymentlink_methods\');
+            const selectedMethods = JSON.parse(localStorage.getItem(\'mollie_paymentlink_methods\'));
             if (!selectedMethods || !paymentMethods) {
                 return;
             }
@@ -45,11 +45,17 @@ $scriptString = <<<SCRIPT
         saveSelectedMethods();
         setSelectedMethods();
 
-        document.getElementById('order-billing_method').addEventListener('DOMSubtreeModified', () => {
+        document.getElementById(\'order-billing_method\').addEventListener(\'DOMSubtreeModified\', () => {
             saveSelectedMethods();
             setSelectedMethods();
         })
     });
-SCRIPT;
+';
 
-echo $secureRenderer->renderTag('script', [], $scriptString, false);
+// @phpstan-ignore-next-line
+if (isset($secureRenderer)) {
+    echo $secureRenderer->renderTag('script', [], $scriptString, false);
+    return;
+}
+
+echo '<script>' . $scriptString . '</script>';

--- a/view/adminhtml/templates/order/shipment/create/payment_hold_warning.phtml
+++ b/view/adminhtml/templates/order/shipment/create/payment_hold_warning.phtml
@@ -16,12 +16,12 @@ use Magento\Framework\View\Helper\SecureHtmlRenderer;
 </div>
 
 <?php
-$scriptString = <<<SCRIPT
+$scriptString = '
     (() => {
-        let warningElement = document.querySelector('.mollie-manual-capture-warning');
-        let fields = Array.from(document.querySelectorAll('.qty-item'));
+        let warningElement = document.querySelector(\'.mollie-manual-capture-warning\');
+        let fields = Array.from(document.querySelectorAll(\'.qty-item\'));
         fields.forEach(function (item) {
-            item.addEventListener('change', function (event) {
+            item.addEventListener(\'change\', function (event) {
                 checkFields();
             });
         });
@@ -31,11 +31,17 @@ $scriptString = <<<SCRIPT
                 return element.value != element.defaultValue;
             })
 
-            warningElement.style.display = alteredFields.length ? 'block' : 'none';
+            warningElement.style.display = alteredFields.length ? \'block\' : \'none\';
         }
 
         checkFields();
     })();
-SCRIPT;
+';
 
-echo $secureRenderer->renderTag('script', [], $scriptString, false);
+// @phpstan-ignore-next-line
+if (isset($secureRenderer)) {
+    echo $secureRenderer->renderTag('script', [], $scriptString, false);
+    return;
+}
+
+echo '<script>' . $scriptString . '</script>';

--- a/view/adminhtml/templates/order/shipment/create/payment_hold_warning.phtml
+++ b/view/adminhtml/templates/order/shipment/create/payment_hold_warning.phtml
@@ -1,14 +1,22 @@
 <?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
 
 declare(strict_types=1);
-?>
 
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var SecureHtmlRenderer $secureRenderer */
+?>
 <div class="mollie-manual-capture-warning message message-warning">
     Please note: You are creating a partial shipment, but it's only possible to capture the payment once.
     Please double-check you are shipping the correct items.
 </div>
 
-<script>
+<?php
+$scriptString = <<<SCRIPT
     (() => {
         let warningElement = document.querySelector('.mollie-manual-capture-warning');
         let fields = Array.from(document.querySelectorAll('.qty-item'));
@@ -28,4 +36,6 @@ declare(strict_types=1);
 
         checkFields();
     })();
-</script>
+SCRIPT;
+
+echo $secureRenderer->renderTag('script', [], $scriptString, false);

--- a/view/adminhtml/templates/system/config/button/apikey.phtml
+++ b/view/adminhtml/templates/system/config/button/apikey.phtml
@@ -1,15 +1,19 @@
 <?php
-/**
- * Copyright © 2018 Magmodules.eu. All rights reserved.
+/*
+ * Copyright Magmodules.eu. All rights reserved.
  * See COPYING.txt for license details.
  */
 
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Mollie\Payment\Block\Adminhtml\System\Config\Form\Apikey\Checker;
+
 /**
- * @see \Mollie\Payment\Block\Adminhtml\System\Config\Form\Apikey\Checker
- * @var \Mollie\Payment\Block\Adminhtml\System\Config\Form\Apikey\Checker $block
+ * @see Checker
+ * @var Checker $block
+ * @var SecureHtmlRenderer $secureRenderer
  */
-?>
-<script>
+
+$scriptString = <<<SCRIPT
     require([
         'jquery',
         'prototype'
@@ -20,7 +24,7 @@
                 "test_key": jQuery("#mollie_general_api_details_apikey_test").val(),
                 "live_key": jQuery("#mollie_general_api_details_apikey_live").val()
             	};
-            new Ajax.Request('<?= $block->getAjaxUrl() ?>', {
+            new Ajax.Request('{$block->getAjaxUrl()}', {
                 parameters: params,
                 loaderArea: false,
                 asynchronous: true,
@@ -45,5 +49,8 @@
             });
         });
     });
-</script>
-<?= $block->getButtonHtml() ?>
+SCRIPT;
+
+echo $secureRenderer->renderTag('script', [], $scriptString, false);
+
+echo $block->getButtonHtml();

--- a/view/adminhtml/templates/system/config/button/apikey.phtml
+++ b/view/adminhtml/templates/system/config/button/apikey.phtml
@@ -13,44 +13,52 @@ use Mollie\Payment\Block\Adminhtml\System\Config\Form\Apikey\Checker;
  * @var SecureHtmlRenderer $secureRenderer
  */
 
-$scriptString = <<<SCRIPT
+$scriptString = '
     require([
-        'jquery',
-        'prototype'
+        \'jquery\',
+        \'prototype\'
     ], function (jQuery) {
-        var resultSpan = jQuery('#result_apikey');
-        jQuery('#apikey_button').click(function () {
+        var resultSpan = jQuery(\'#result_apikey\');
+        jQuery(\'#apikey_button\').click(function () {
             var params = {
                 "test_key": jQuery("#mollie_general_api_details_apikey_test").val(),
                 "live_key": jQuery("#mollie_general_api_details_apikey_live").val()
             	};
-            new Ajax.Request('{$block->getAjaxUrl()}', {
+            new Ajax.Request(\'' . $block->getAjaxUrl() . '\', {
                 parameters: params,
                 loaderArea: false,
                 asynchronous: true,
                 onCreate: function () {
-                    resultSpan.find('.connecting').show();
-                    resultSpan.find('.result').hide();
+                    resultSpan.find(\'.connecting\').show();
+                    resultSpan.find(\'.result\').hide();
                 },
                 onSuccess: function (response) {
-                    resultSpan.find('.connecting').hide();
-                    var resultText = '';
+                    resultSpan.find(\'.connecting\').hide();
+                    var resultText = \'\';
                     if (response.status > 200) {
                         resultText = response.statusText;
                     } else {
                         var json = response.responseJSON;
-                        if (typeof json.msg != 'undefined') {
+                        if (typeof json.msg != \'undefined\') {
                             resultText = json.msg;
                         }
                     }
-                    resultSpan.find('.result').show();
-                    resultSpan.find('.result').html(resultText);
+                    resultSpan.find(\'.result\').show();
+                    resultSpan.find(\'.result\').html(resultText);
                 }
             });
         });
     });
-SCRIPT;
+';
 
-echo $secureRenderer->renderTag('script', [], $scriptString, false);
+// @phpstan-ignore-next-line
+if (isset($secureRenderer)) {
+    echo $secureRenderer->renderTag('script', [], $scriptString, false);
+}
+
+// @phpstan-ignore-next-line
+if (!isset($secureRenderer)) {
+    echo '<script>' . $scriptString . '</script>';
+}
 
 echo $block->getButtonHtml();

--- a/view/adminhtml/templates/system/config/button/compatibility.phtml
+++ b/view/adminhtml/templates/system/config/button/compatibility.phtml
@@ -1,24 +1,28 @@
 <?php
-/**
- * Copyright © 2018 Magmodules.eu. All rights reserved.
+/*
+ * Copyright Magmodules.eu. All rights reserved.
  * See COPYING.txt for license details.
  */
 
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Mollie\Payment\Block\Adminhtml\System\Config\Form\Compatibility\Checker;
+
 /**
- * @see \Mollie\Payment\Block\Adminhtml\System\Config\Form\Compatibility\Checker
- * @var \Mollie\Payment\Block\Adminhtml\System\Config\Form\Compatibility\Checker $block
+ * @see Checker
+ * @var Checker $block
+ * @var SecureHtmlRenderer $secureRenderer
  */
-?>
-<script>
+
+$scriptString = <<<SCRIPT
     require([
         'jquery',
         'mage/translate',
         'prototype',
-    ], function (jQuery, $t) {
+    ], function (jQuery, \$t) {
         var resultSpan = jQuery('#result_compatibility');
         jQuery('#compatibility_button').click(function () {
             var params = {};
-            new Ajax.Request('<?= $block->getAjaxUrl() ?>', {
+            new Ajax.Request('{$block->getAjaxUrl()}', {
                 parameters: params,
                 loaderArea: false,
                 asynchronous: true,
@@ -36,7 +40,7 @@
                         if (typeof json.msg != 'undefined') {
                             resultText = json.msg;
                         } else {
-                            resultText = $t('Invalid response received. This indicates an unknown problem.');
+                            resultText = \$t('Invalid response received. This indicates an unknown problem.');
                         }
                     }
                     resultSpan.find('.result').show();
@@ -46,5 +50,8 @@
         });
 
     });
-</script>
-<?= $block->getButtonHtml() ?>
+SCRIPT;
+
+echo $secureRenderer->renderTag('script', [], $scriptString, false);
+
+echo $block->getButtonHtml();

--- a/view/adminhtml/templates/system/config/button/compatibility.phtml
+++ b/view/adminhtml/templates/system/config/button/compatibility.phtml
@@ -13,45 +13,53 @@ use Mollie\Payment\Block\Adminhtml\System\Config\Form\Compatibility\Checker;
  * @var SecureHtmlRenderer $secureRenderer
  */
 
-$scriptString = <<<SCRIPT
+$scriptString = '
     require([
-        'jquery',
-        'mage/translate',
-        'prototype',
+        \'jquery\',
+        \'mage/translate\',
+        \'prototype\',
     ], function (jQuery, \$t) {
-        var resultSpan = jQuery('#result_compatibility');
-        jQuery('#compatibility_button').click(function () {
+        var resultSpan = jQuery(\'#result_compatibility\');
+        jQuery(\'#compatibility_button\').click(function () {
             var params = {};
-            new Ajax.Request('{$block->getAjaxUrl()}', {
+            new Ajax.Request(\'' . $block->getAjaxUrl() . '\', {
                 parameters: params,
                 loaderArea: false,
                 asynchronous: true,
                 onCreate: function () {
-                    resultSpan.find('.connecting').show();
-                    resultSpan.find('.result').hide();
+                    resultSpan.find(\'.connecting\').show();
+                    resultSpan.find(\'.result\').hide();
                 },
                 onSuccess: function (response) {
-                    resultSpan.find('.connecting').hide();
-                    var resultText = '';
+                    resultSpan.find(\'.connecting\').hide();
+                    var resultText = \'\';
                     if (response.status > 200) {
                         resultText = response.statusText;
                     } else {
                         var json = response.responseJSON;
-                        if (typeof json.msg != 'undefined') {
+                        if (typeof json.msg != \'undefined\') {
                             resultText = json.msg;
                         } else {
-                            resultText = \$t('Invalid response received. This indicates an unknown problem.');
+                            resultText = \$t(\'Invalid response received. This indicates an unknown problem.\');
                         }
                     }
-                    resultSpan.find('.result').show();
-                    resultSpan.find('.result').html(resultText);
+                    resultSpan.find(\'.result\').show();
+                    resultSpan.find(\'.result\').html(resultText);
                 }
             });
         });
 
     });
-SCRIPT;
+';
 
-echo $secureRenderer->renderTag('script', [], $scriptString, false);
+// @phpstan-ignore-next-line
+if (isset($secureRenderer)) {
+    echo $secureRenderer->renderTag('script', [], $scriptString, false);
+}
+
+// @phpstan-ignore-next-line
+if (!isset($secureRenderer)) {
+    echo '<script>' . $scriptString . '</script>';
+}
 
 echo $block->getButtonHtml();


### PR DESCRIPTION
* Bugfix: Use payment link expiry date when no method for expiry is found #796
* Bugfix: Remove reorder check #795
* Bugfix: Render script in secure tag #797
* Improvement: Prevent multiple captured amount notifications when completed #798
* Bugfix: Do not set shipping method for Apple Pay when ordering digital products
* Bugfix: Redirect customer to success page when the Mollie order is 'shipping'