### PR TITLE
Open Mollie Dashboard in New Tab

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -50,7 +50,7 @@
                        showInWebsite="1" showInStore="1">
                     <label>API Details</label>
                     <frontend_model>Mollie\Payment\Block\Adminhtml\Render\Heading</frontend_model>
-                    <comment><![CDATA[You can find your Api Keys in your <a href="https://www.mollie.com/dashboard/" title="Mollie Profiles">Mollie Profile</a>.<br>]]></comment>
+                    <comment><![CDATA[You can find your Api Keys in your <a href="https://www.mollie.com/dashboard/" title="Mollie Profiles" target="_blank">Mollie Profile</a>.<br>]]></comment>
                 </field>
                 <field id="type" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
                        showInStore="1">


### PR DESCRIPTION
# Description
Replacing the current admin window and causing unsaved changes to be lost is not a great experience.

---

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [x] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When I click on the `Mollie Profile` link in the API configuration group, the browser navigates to the Mollie dashboard - causing any unsaved configuration changes to be lost, which can be annoying.

**Scenario to test this code:**

1. Log into the admin
2. Navigate to the Mollie API configuration options: `Stores -> Settings -> Configuration -> Mollie -> General -> API Details`
3. Click on the `Mollie Profile` link
4. Observe the Mollie dashboard opening in a new tab rather than the existing one
