### PR TITLE
Fix fatal error in checkout if no api keys

### DIFF
--- a/Model/MollieConfigProvider.php
+++ b/Model/MollieConfigProvider.php
@@ -141,7 +141,7 @@ class MollieConfigProvider implements ConfigProviderInterface
     public function getConfig(): array
     {
         // Do not load the config when on the cart page.
-        if ($this->request->getControllerName() === 'cart') {
+        if (!$this->config->isModuleEnabled() || $this->request->getControllerName() === 'cart') {
             return [];
         }
 


### PR DESCRIPTION
**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [+] Checkout

**Please describe the bug/feature/etc this PR contains:**
Fix fatal error in the checkout if the API key is not provided or wrong configured.

Steps to reproduce:
Install the module on a fresh instance and go to checkout. Checkout is not loading at all due to an exception.

Stack trace:
[2024-11-26T14:18:14.740156+00:00] main.CRITICAL: Mollie\Api\Exceptions\ApiException: [2024-11-26T14:18:14+0000] Invalid API key: ''. An API key must start with 'test_' or
'live_' and must be at least 30 characters long. in /var/www/projects/magento2/vendor/mollie/mollie-api-php/src/MollieApiClient.php:519
Stack trace:
#0 /var/www/projects/magento2/vendor/mollie/magento2/Service/Mollie/MollieApiClient.php(74): Mollie\Api\MollieApiClient->setApiKey('')
#1 /var/www/projects/magento2/vendor/mollie/magento2/Service/Mollie/MollieApiClient.php(60): Mollie\Payment\Service\Mollie\MollieApiClient->loadByApiKey('')
#2 /var/www/projects/clarusmagento2/vendor/mollie/magento2/Model/MollieConfigProvider.php(226): Mollie\Payment\Service\Mollie\MollieApiClient->loadByStore()
#3 /var/www/projects/magento2/vendor/mollie/magento2/Model/MollieConfigProvider.php(180): Mollie\Payment\Model\MollieConfigProvider->getIssuers('mollie_methods_...', Array)
#4 /var/www/projects/magento2/vendor/magento/module-checkout/Model/CompositeConfigProvider.php(39): Mollie\Payment\Model\MollieConfigProvider->getConfig()
#5 /var/www/projects/magento2/vendor/magento/module-checkout/Block/Onepage.php(106): Magento\Checkout\Model\CompositeConfigProvider->getConfig()
#6 /var/www/projects/magento2/generated/code/Magento/Checkout/Block/Onepage/Interceptor.php(41): Magento\Checkout\Block\Onepage->getCheckoutConfig()
#7 /var/www/projects/magento2vendor/magento/module-checkout/Block/Onepage.php(128): Magento\Checkout\Block\Onepage\Interceptor->getCheckoutConfig()
#8 /var/www/projects/clarusmagento2/generated/code/Magento/Checkout/Block/Onepage/Interceptor.php(59): Magento\Checkout\Block\Onepage->getSerializedCheckoutConfig()
#9 /var/www/projects/magento2/vendor/magento/module-checkout/view/frontend/templates/onepage.phtml(27): Magento\Checkout\Block\Onepage\Interceptor->getSerializedCheckoutConfig()