### PR TITLE
PIMAG-679 | Bugfix: Catch getIssuer api key errors

### DIFF
--- a/Model/MollieConfigProvider.php
+++ b/Model/MollieConfigProvider.php
@@ -223,10 +223,16 @@ class MollieConfigProvider implements ConfigProviderInterface
 
     private function getIssuers(string $code, array $config): array
     {
-        $mollieApi = $this->mollieApiClient->loadByStore();
         $issuerListType = $this->config->getIssuerListType($code, $this->storeManager->getStore()->getId());
         $config['payment']['issuersListType'][$code] = $issuerListType;
-        $config['payment']['issuers'][$code] = $this->getIssuers->execute($mollieApi, $code, $issuerListType);
+
+        try {
+            $mollieApi = $this->mollieApiClient->loadByStore();
+            $config['payment']['issuers'][$code] = $this->getIssuers->execute($mollieApi, $code, $issuerListType);
+        } catch (\Exception $exception) {
+            $this->config->addTolog('error', 'Unable to load issuers: ' . $exception->getMessage());
+            $config['payment']['issuers'][$code] = [];
+        }
 
         return $config;
     }

--- a/Service/Mollie/Wrapper/MollieApiClientFallbackWrapper.php
+++ b/Service/Mollie/Wrapper/MollieApiClientFallbackWrapper.php
@@ -2,10 +2,17 @@
 
 namespace Mollie\Payment\Service\Mollie\Wrapper;
 
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Exceptions\IncompatiblePlatform;
 use Mollie\Api\MollieApiClient;
 
 class MollieApiClientFallbackWrapper extends MollieApiClient
 {
+    /**
+     * @throws ApiException If there's an API error during initialization.
+     * @throws IncompatiblePlatform If the platform is not compatible.
+     * @return void
+     */
     public function initializeEndpoints()
     {
         parent::initializeEndpoints();


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...