### PR TITLE
PIMAG-681 | Bugfix: Add Magento Discount to order lines

### DIFF
--- a/Service/Order/Lines/Generator/MagentoDiscount.php
+++ b/Service/Order/Lines/Generator/MagentoDiscount.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Order\Lines\Generator;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Api\Types\OrderLineType;
+use Mollie\Payment\Helper\General;
+
+class MagentoDiscount implements GeneratorInterface
+{
+    /**
+     * @var General
+     */
+    private $mollieHelper;
+
+    public function __construct(
+        General $mollieHelper
+    ) {
+        $this->mollieHelper = $mollieHelper;
+    }
+
+    public function process(OrderInterface $order, array $orderLines): array
+    {
+        if (!$order->getBaseDiscountAmount()) {
+            return $orderLines;
+        }
+
+        $forceBaseCurrency = (bool)$this->mollieHelper->useBaseCurrency($order->getStoreId());
+        $currency = $forceBaseCurrency ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
+        $amount = (float)$order->getData(($forceBaseCurrency ? 'base_' : '') . 'discount_amount');
+
+        $orderLines[] = [
+            'type' => OrderLineType::TYPE_DISCOUNT,
+            'name' => __('Magento Discount'),
+            'quantity' => 1,
+            'unitPrice' => $this->mollieHelper->getAmountArray($currency, $amount),
+            'totalAmount' => $this->mollieHelper->getAmountArray($currency, $amount),
+            'vatRate' => '0.00',
+            'vatAmount' => $this->mollieHelper->getAmountArray($currency, 0),
+        ];
+
+        return $orderLines;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -158,6 +158,7 @@
     <type name="Mollie\Payment\Service\Order\Lines\OrderLinesGenerator">
         <arguments>
             <argument name="generators" xsi:type="array">
+                <item name="magento_discount" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\MagentoDiscount</item>
                 <item name="fooman_totals" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\FoomanTotals</item>
                 <item name="weee_fee" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\WeeeFeeGenerator</item>
                 <item name="mageworx_rewardpoints" xsi:type="object">Mollie\Payment\Service\Order\Lines\Generator\MageWorxRewardPoints</item>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...