### PR TITLE
PIMAG-680 | Bugfix: Allow to select the correct status for payment link #825

### DIFF
--- a/Model/Adminhtml/Source/PendingPaymentStatus.php
+++ b/Model/Adminhtml/Source/PendingPaymentStatus.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Model\Adminhtml\Source;
+
+use Magento\Sales\Model\Config\Source\Order\Status;
+
+class PendingPaymentStatus extends Status
+{
+    /**
+     * @var string
+     */
+    protected $_stateStatuses = \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT;
+}

--- a/etc/adminhtml/methods/paymentlink.xml
+++ b/etc/adminhtml/methods/paymentlink.xml
@@ -53,8 +53,8 @@
             </depends>
         </field>
         <field id="order_status_new" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Status New</label>
-            <source_model>Mollie\Payment\Model\Adminhtml\Source\NewStatus</source_model>
+            <label>Status After Creation</label>
+            <source_model>Mollie\Payment\Model\Adminhtml\Source\PendingPaymentStatus</source_model>
             <config_path>payment/mollie_methods_paymentlink/order_status_new</config_path>
             <depends>
                 <field id="active">1</field>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...