### PR TITLE
PIMAG-686 | Improvement: Add test scenario for when the API key is not set #829

### DIFF
--- a/.github/workflows/end-2-end-test.yml
+++ b/.github/workflows/end-2-end-test.yml
@@ -51,14 +51,20 @@ jobs:
         include:
           - PHP_VERSION: php74-fpm
             MAGENTO_VERSION: 2.3.7-p4
+            NO_API_KEY_TEST: false
           - PHP_VERSION: php82-fpm
             MAGENTO_VERSION: 2.4.6-p5
+            NO_API_KEY_TEST: false
+          - PHP_VERSION: php74-fpm
+            MAGENTO_VERSION: 2.3.7-p4
+            NO_API_KEY_TEST: true
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.PHP_VERSION }}
       MAGENTO_VERSION: ${{ matrix.MAGENTO_VERSION }}
       MOLLIE_API_KEY_TEST: ${{ secrets.MOLLIE_API_KEY_TEST }}
       NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+      NO_API_KEY_TEST: ${{ matrix.NO_API_KEY_TEST }}
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       CYPRESS_TESTRAIL_DOMAIN: ${{ secrets.TESTRAIL_DOMAIN }}
       CYPRESS_TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
@@ -93,9 +99,14 @@ jobs:
           docker exec magento-project-community-edition php /data/merge-config.php
           docker exec magento-project-community-edition ./retry "php bin/magento module:enable Mollie_Payment"
           docker exec magento-project-community-edition ./retry "php bin/magento setup:upgrade --no-interaction"
-          docker exec magento-project-community-edition /bin/bash /data/configure-mollie.sh
           docker exec magento-project-community-edition ./retry "bin/magento config:set payment/mollie_general/use_webhooks custom_url"
           docker exec magento-project-community-edition ./retry "bin/magento config:set payment/mollie_general/custom_webhook_url ${{ env.magento_url }}/mollie/checkout/webhook"
+
+      - name: Configure Mollie
+        run: |
+          if [ ${{ matrix.NO_API_KEY_TEST }} == 'false' ]; then
+            docker exec magento-project-community-edition /bin/bash /data/configure-mollie.sh
+          fi
 
       - name: Prepare Magento
         run: |

--- a/.github/workflows/templates/docker-compose.yml
+++ b/.github/workflows/templates/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     links:
       - "nginx-proxy:magento.test"
     environment:
+      - NO_API_KEY_TEST
       - CYPRESS_TESTRAIL_DOMAIN
       - CYPRESS_TESTRAIL_USERNAME
       - CYPRESS_TESTRAIL_PASSWORD

--- a/.github/workflows/templates/magento/configure-mollie.sh
+++ b/.github/workflows/templates/magento/configure-mollie.sh
@@ -9,67 +9,59 @@ if [ -z "$MOLLIE_API_KEY_TEST" ]; then
 fi
 
 # General configuration
-bin/magento config:set payment/mollie_general/profileid pfl_8yCABHRz37 &
-magerun2 config:store:set payment/mollie_general/apikey_test $MOLLIE_API_KEY_TEST --encrypt &
-bin/magento config:set payment/mollie_general/enabled 1 &
-bin/magento config:set payment/mollie_general/type test &
+bin/magento config:set payment/mollie_general/profileid pfl_8yCABHRz37
+magerun2 config:store:set payment/mollie_general/apikey_test $MOLLIE_API_KEY_TEST --encrypt
+bin/magento config:set payment/mollie_general/enabled 1
+bin/magento config:set payment/mollie_general/type test
 
 # Enable all payment methods
-bin/magento config:set payment/mollie_methods_applepay/active 1 &
-bin/magento config:set payment/mollie_methods_banktransfer/active 1 &
-bin/magento config:set payment/mollie_methods_billie/active 1 &
-bin/magento config:set payment/mollie_methods_blik/active 1 &
-bin/magento config:set payment/mollie_methods_creditcard/active 1 &
-bin/magento config:set payment/mollie_methods_giftcard/active 1 &
-bin/magento config:set payment/mollie_methods_ideal/active 1 &
-bin/magento config:set payment/mollie_methods_kbc/active 1 &
-bin/magento config:set payment/mollie_methods_klarnasliceit/active 1 &
-bin/magento config:set payment/mollie_methods_paypal/active 1 &
-bin/magento config:set payment/mollie_methods_przelewy24/active 1 &
-bin/magento config:set payment/mollie_methods_payconiq/active 1 &
-bin/magento config:set payment/mollie_methods_alma/active 1 &
-bin/magento config:set payment/mollie_methods_bancontact/active 1 &
-bin/magento config:set payment/mollie_methods_bancomatpay/active 1 &
-bin/magento config:set payment/mollie_methods_belfius/active 1 &
-bin/magento config:set payment/mollie_methods_eps/active 1 &
-bin/magento config:set payment/mollie_methods_klarnapaylater/active 1 &
-bin/magento config:set payment/mollie_methods_paymentlink/active 1 &
-bin/magento config:set payment/mollie_methods_paysafecard/active 1 &
-bin/magento config:set payment/mollie_methods_pointofsale/active 1 &
-bin/magento config:set payment/mollie_methods_riverty/active 1 &
-bin/magento config:set payment/mollie_methods_satispay/active 1 &
-bin/magento config:set payment/mollie_methods_sofort/active 1 &
-bin/magento config:set payment/mollie_methods_trustly/active 1 &
-bin/magento config:set payment/mollie_methods_twint/active 1 &
+bin/magento config:set payment/mollie_methods_applepay/active 1
+bin/magento config:set payment/mollie_methods_banktransfer/active 1
+bin/magento config:set payment/mollie_methods_billie/active 1
+bin/magento config:set payment/mollie_methods_blik/active 1
+bin/magento config:set payment/mollie_methods_creditcard/active 1
+bin/magento config:set payment/mollie_methods_giftcard/active 1
+bin/magento config:set payment/mollie_methods_ideal/active 1
+bin/magento config:set payment/mollie_methods_kbc/active 1
+bin/magento config:set payment/mollie_methods_klarnasliceit/active 1
+bin/magento config:set payment/mollie_methods_paypal/active 1
+bin/magento config:set payment/mollie_methods_przelewy24/active 1
+bin/magento config:set payment/mollie_methods_payconiq/active 1
+bin/magento config:set payment/mollie_methods_alma/active 1
+bin/magento config:set payment/mollie_methods_bancontact/active 1
+bin/magento config:set payment/mollie_methods_bancomatpay/active 1
+bin/magento config:set payment/mollie_methods_belfius/active 1
+bin/magento config:set payment/mollie_methods_eps/active 1
+bin/magento config:set payment/mollie_methods_klarnapaylater/active 1
+bin/magento config:set payment/mollie_methods_paymentlink/active 1
+bin/magento config:set payment/mollie_methods_paysafecard/active 1
+bin/magento config:set payment/mollie_methods_pointofsale/active 1
+bin/magento config:set payment/mollie_methods_riverty/active 1
+bin/magento config:set payment/mollie_methods_satispay/active 1
+bin/magento config:set payment/mollie_methods_sofort/active 1
+bin/magento config:set payment/mollie_methods_trustly/active 1
+bin/magento config:set payment/mollie_methods_twint/active 1
 
 # Enable Components
-bin/magento config:set payment/mollie_methods_creditcard/use_components 1 &
-
-# Enable QR
-bin/magento config:set payment/mollie_methods_ideal/add_qr 1 &
-
-# Disable webhooks
-bin/magento config:set payment/mollie_general/use_webhooks disabled &
+bin/magento config:set payment/mollie_methods_creditcard/use_components 1
 
 # Configure currency for the swiss store view
-bin/magento config:set currency/options/allow EUR,CHF,PLN &
+bin/magento config:set currency/options/allow EUR,CHF,PLN
 
 # Swiss scope
-bin/magento config:set currency/options/default CHF --scope=ch &
-bin/magento config:set payment/mollie_general/currency 0 --scope=ch &
+bin/magento config:set currency/options/default CHF --scope=ch --scope-code=ch
+bin/magento config:set payment/mollie_general/currency 0 --scope=ch --scope-code=ch
 
 # Polish scope
-bin/magento config:set currency/options/default PLN --scope=pl &
-bin/magento config:set payment/mollie_general/currency 0 --scope=pl &
+bin/magento config:set currency/options/default PLN --scope=pl --scope-code=pl
+bin/magento config:set payment/mollie_general/currency 0 --scope=pl --scope-code=pl
 
 # Disable the use of the base currency
-bin/magento config:set payment/mollie_general/currency 0 &
+bin/magento config:set payment/mollie_general/currency 0
 
 # Insert rates, otherwise the currency switcher won't show
-magerun2 db:query 'INSERT INTO `directory_currency_rate` (`currency_from`, `currency_to`, `rate`) VALUES ("EUR", "PLN", 1.0);' &
-magerun2 db:query 'INSERT INTO `directory_currency_rate` (`currency_from`, `currency_to`, `rate`) VALUES ("EUR", "CHF", 1.0);' &
-
-wait
+magerun2 db:query 'INSERT INTO `directory_currency_rate` (`currency_from`, `currency_to`, `rate`) VALUES ("EUR", "PLN", 1.0);'
+magerun2 db:query 'INSERT INTO `directory_currency_rate` (`currency_from`, `currency_to`, `rate`) VALUES ("EUR", "CHF", 1.0);'
 
 if grep -q Magento_TwoFactorAuth "app/etc/config.php"; then
     ./retry "php bin/magento module:disable Magento_TwoFactorAuth -f"

--- a/Test/End-2-end/cypress.config.js
+++ b/Test/End-2-end/cypress.config.js
@@ -22,6 +22,18 @@ module.exports = defineConfig({
         config.env.CI = true
       }
 
+      config.excludeSpecPattern = ['cypress/e2e/magento/no-api-key.cy.js'];
+      if (typeof process.env.NO_API_KEY_TEST != 'undefined' && process.env.NO_API_KEY_TEST == 'true') {
+        console.info('Running tests without API key');
+
+        config.specPattern = ['cypress/e2e/magento/no-api-key.cy.js'];
+        config.excludeSpecPattern = [];
+
+        return config;
+      }
+
+      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+
       // Retrieve available method
       await new Promise((resolve, reject) => {
         var https = require('follow-redirects').https;

--- a/Test/End-2-end/cypress/e2e/magento/no-api-key.cy.js
+++ b/Test/End-2-end/cypress/e2e/magento/no-api-key.cy.js
@@ -1,0 +1,13 @@
+import CheckoutPaymentPage from "Pages/frontend/CheckoutPaymentPage";
+import VisitCheckoutPaymentCompositeAction from "CompositeActions/VisitCheckoutPaymentCompositeAction";
+
+const checkoutPaymentPage = new CheckoutPaymentPage();
+const visitCheckoutPayment = new VisitCheckoutPaymentCompositeAction();
+
+describe('Test without API key', () => {
+    it('C4225556: Can still use the webshop when no API key is set and the module is disabled', () => {
+        visitCheckoutPayment.visit();
+
+        cy.contains('Ship To:').should('be.visible');
+    });
+});


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...