### PR TITLE
PIMAG-714 | Improvement: Improved message when transaction fails

### DIFF
--- a/Service/Mollie/Order/AddResultMessage.php
+++ b/Service/Mollie/Order/AddResultMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Order;
+
+use Magento\Framework\Message\ManagerInterface;
+use Mollie\Payment\Service\Mollie\GetMollieStatusResult;
+
+class AddResultMessage
+{
+    /**
+     * @var ManagerInterface
+     */
+    private $messageManager;
+
+    public function __construct(
+        ManagerInterface $messageManager
+    ) {
+        $this->messageManager = $messageManager;
+    }
+
+    public function execute(GetMollieStatusResult $result): void
+    {
+        if ($result->getStatus() == 'canceled') {
+            $this->messageManager->addNoticeMessage(__('Payment canceled, please try again.'));
+            return;
+        }
+
+        $this->messageManager->addErrorMessage(__('Transaction failed. Please verify your billing information and payment method, and try again.'));
+    }
+}

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","Bei der Überprüfung des Transaktionsstatus ist ein Fehler aufgetreten."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Transaktion fehlgeschlagen. Bitte überprüfen Sie Ihre Rechnungsinformationen und Zahlungsmethode, und versuchen Sie es erneut."
 "Payment canceled, please try again.","Zahlung abgebrochen. Bitte versuchen Sie es noch einmal."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Die Zahlung vom Typ %1 wurde abgelehnt. Die Entscheidung basiert auf der Bestellung und dem Ergebnis der Risikobewertung."
 "Payment Method not found","Zahlungsmethode nicht gefunden"
 "Canceled because an error occurred while redirecting the customer to Mollie","Die Zahlung wurde wegen eines Fehlers bei der Weiterleitung des Kunden zu Mollie abgebrochen"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Bei der Verbindung mit %1 wurde die Zeitüberschreitung erreicht. Das kann an einer fehlenden Netzwerkverbindung liegen. Bitte versuchen Sie es noch einmal oder wählen Sie eine andere Zahlungsmethode aus."

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","There was an error checking the transaction status."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Transaction failed. Please verify your billing information and payment method, and try again."
 "Payment canceled, please try again.","Payment canceled, please try again."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment."
 "Payment Method not found","Payment Method not found"
 "Canceled because an error occurred while redirecting the customer to Mollie","Canceled because an error occurred while redirecting the customer to Mollie"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method."

--- a/i18n/es_ES.csv
+++ b/i18n/es_ES.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","Se ha producido un error al comprobar el estado de la transacción."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Transacción fallida. Por favor, verifica tu información de facturación y método de pago, e inténtalo de nuevo."
 "Payment canceled, please try again.","Pago cancelado, inténtelo de nuevo."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","El pago del tipo %1 ha sido rechazado. La decisión se basa en el pedido y el resultado de la evaluación de riesgos."
 "Payment Method not found","Método de pago no encontrado"
 "Canceled because an error occurred while redirecting the customer to Mollie","Cancelado porque se ha producido un error al redirigir al cliente a Mollie"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Se agotó el tiempo de espera durante la conexión con %1, posiblemente debido a una interrupción. Por favor, inténtelo de nuevo o seleccione otro método de pago."

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","Une erreur s'est produite lors de la vérification du statut de la transaction."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Échec de la transaction. Veuillez vérifier vos informations de facturation et votre méthode de paiement, puis réessayez."
 "Payment canceled, please try again.","Paiement annulé, veuillez réessayer."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Le paiement de type %1 a été rejeté. La décision s'appuie sur la commande et la conclusion de l'évaluation des risques."
 "Payment Method not found","Aucune méthode de paiement n'a été trouvée"
 "Canceled because an error occurred while redirecting the customer to Mollie","Annulée, car une erreur est survenue pendant la redirection du client vers Mollie"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Un délai est survenu lors de la connexion à %1, une panne peut en être l'origine. Veuillez réessayer ou sélectionner une autre méthode de paiement."

--- a/i18n/it_IT.csv
+++ b/i18n/it_IT.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","Si è verificato un errore nella verifica dello stato della transazione."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Transazione fallita. Verifica le tue informazioni di fatturazione e il metodo di pagamento e riprova."
 "Payment canceled, please try again.","Pagamento annullato, riprova per favore."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Il pagamento del tipo %1 è stato rifiutato. La decisione si basa sull'ordine e sull'esito della valutazione dei rischi."
 "Payment Method not found","Metodo di pagamento non trovato"
 "Canceled because an error occurred while redirecting the customer to Mollie","Annullato perché si è verificato un errore durante il reindirizzamento del cliente a Mollie."
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Si è verificato un timeout durante la connessione a %1 , che potrebbe essere il risultato di un'interruzione. Si prega di riprovare o di selezionare un altro metodo di pagamento."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -20,7 +20,6 @@
 "There was an error checking the transaction status.","Er is een fout opgetreden bij het controleren van de transactiestatus."
 "Transaction failed. Please verify your billing information and payment method, and try again.","Transactie mislukt. Controleer uw factuurgegevens en betaalmethode, en probeer het opnieuw."
 "Payment canceled, please try again.","Betaling geannuleerd, probeer het opnieuw."
-"Payment of type %1 has been rejected. Decision is based on order and outcome of risk assessment.","Betaling van het type %1 is geweigerd. De beslissing is gebaseerd op de bestelling en het resultaat van de risicobeoordeling."
 "Payment Method not found","Betaalmethode niet gevonden"
 "Canceled because an error occurred while redirecting the customer to Mollie","Geannuleerd, omdat er een fout is opgetreden bij het doorsturen van de klant naar Mollie"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Er is een time-out opgetreden tijdens de verbinding met %1, dit kan het gevolg zijn van een storing. Probeer het opnieuw of kies een andere betaalmethode."


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...