### PR TITLE
[PIMAG-786] Bugfix: Call startTransaction for backend point of sale orders #888

### DIFF
--- a/Observer/SalesModelServiceQuoteSubmitSuccess/StartTransactionForPointOfSaleOrders.php
+++ b/Observer/SalesModelServiceQuoteSubmitSuccess/StartTransactionForPointOfSaleOrders.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Observer\SalesModelServiceQuoteSubmitSuccess;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Model\Methods\Pointofsale;
+use Mollie\Payment\Model\Mollie;
+
+class StartTransactionForPointOfSaleOrders implements ObserverInterface
+{
+    /**
+     * @var Mollie
+     */
+    private $mollie;
+    /**
+     * @var State
+     */
+    private $state;
+
+    public function __construct(
+        Mollie $mollie,
+        State $state
+    ) {
+        $this->mollie = $mollie;
+        $this->state = $state;
+    }
+
+    public function execute(Observer $observer)
+    {
+        if (!$observer->hasData('order')) {
+            return;
+        }
+
+
+        /** @var OrderInterface $order */
+        $order = $observer->getData('order');
+
+        $area = $this->state->getAreaCode();
+        if ($order->getPayment()->getData('method') != Pointofsale::CODE ||
+            $area != Area::AREA_ADMINHTML
+        ) {
+            return;
+        }
+
+        $this->mollie->startTransaction($order);
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -57,6 +57,7 @@
     </event>
     <event name="checkout_submit_all_after">
         <observer name="mollie_starttransaction_for_instant_purchase_orders" instance="Mollie\Payment\Observer\CheckoutSubmitAllAfter\StartTransactionForInstantPurchaseOrders" />
+        <observer name="mollie_starttransaction_for_pointofsale_orders" instance="Mollie\Payment\Observer\SalesModelServiceQuoteSubmitSuccess\StartTransactionForPointOfSaleOrders" />
     </event>
     <event name="sales_quote_item_set_product">
         <observer name="mollie_add_subscription_product_type_options" instance="Mollie\Payment\Observer\SalesQuoteItemSetProduct\SetSubscriptionDataOnBuyRequest" />


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...