### PR TITLE
PIMAG-786 | Fix Cron Error When Product Has Been Deleted

### DIFF
--- a/Service/Order/PaymentReminder.php
+++ b/Service/Order/PaymentReminder.php
@@ -152,7 +152,7 @@ class PaymentReminder
     {
         /** @var OrderItemInterface $item */
         foreach ($order->getAllVisibleItems() as $item) {
-            if (!$item->getProduct()->isSaleable()) {
+            if (!$item->getProduct() || !$item->getProduct()->isSaleable()) {
                 return false;
             }
         }


### PR DESCRIPTION
- [X] The code is working on a plain Magento 2 installation.
- [X] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [X] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
Second Chance Email

**Please describe the bug/feature/etc this PR contains:**

    The following cronjob failed:

    Job	mollie_send_pending_payment_reminders
    Messages	Error when running a cron job: Call to a member function isSaleable() on null
    Executed at	2025-05-02 09:00:09

**Scenario to test this code:**

1. Configure second chance email.
2. Cancel order payment.
3. Delete ordered product.
4. Wait for second chance email cronjob.
5. Observe above error.