### PR TITLE
Bugfix: Limit methods for Payments API too

### DIFF
--- a/Model/Client/Orders.php
+++ b/Model/Client/Orders.php
@@ -266,10 +266,6 @@ class Orders extends AbstractModel
             $orderData['payment']['dueDate'] = $this->mollieHelper->getBanktransferDueDate($storeId);
         }
 
-        if (isset($additionalData['limited_methods'])) {
-            $orderData['method'] = $additionalData['limited_methods'];
-        }
-
         if ($this->expires->availableForMethod($this->methodCode->getExpiresAtMethod(), $storeId)) {
             $orderData['expiresAt'] = $this->expires->atDateForMethod(
                 $this->methodCode->getExpiresAtMethod(),

--- a/Service/Order/TransactionPart/LimitedMethods.php
+++ b/Service/Order/TransactionPart/LimitedMethods.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Order\TransactionPart;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Service\Order\TransactionPartInterface;
+
+class LimitedMethods implements TransactionPartInterface
+{
+    public function process(OrderInterface $order, $apiMethod, array $transaction): array
+    {
+        $additionalData = $order->getPayment()->getAdditionalInformation();
+
+        if (!array_key_exists('limited_methods', $additionalData) || !$additionalData['limited_methods']) {
+            return $transaction;
+        }
+
+        $transaction['method'] = $additionalData['limited_methods'];
+
+        return $transaction;
+    }
+}

--- a/Test/Integration/Service/Order/TransactionPart/LimitedMethodsTest.php
+++ b/Test/Integration/Service/Order/TransactionPart/LimitedMethodsTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Order\TransactionPart;
+
+use Mollie\Payment\Service\Order\TransactionPart\LimitedMethods;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class LimitedMethodsTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testSetsTheLimitedMethodsWhenValid(): void
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setAdditionalInformation('limited_methods', ['ideal', 'bancontact']);
+
+        /** @var LimitedMethods $instance */
+        $instance = $this->objectManager->create(LimitedMethods::class);
+
+        $result = $instance->process($order, 'orders', ['method' => 'creditcard']);
+
+        $this->assertArrayHasKey('method', $result);
+        $this->assertEquals(['ideal', 'bancontact'], $result['method']);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testDoesNothingWhenTheValueIsEmpty(): void
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setAdditionalInformation('limited_methods', rand(0, 1) == 1 ? null : '');
+
+        /** @var LimitedMethods $instance */
+        $instance = $this->objectManager->create(LimitedMethods::class);
+
+        $result = $instance->process($order, 'orders', ['method' => 'creditcard']);
+
+        $this->assertEquals('creditcard', $result['method']);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testDoesNothingWhenNotSet(): void
+    {
+        $order = $this->loadOrderById('100000001');
+
+        /** @var LimitedMethods $instance */
+        $instance = $this->objectManager->create(LimitedMethods::class);
+
+        $result = $instance->process($order, 'orders', ['method' => 'creditcard']);
+
+        $this->assertEquals('creditcard', $result['method']);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -129,6 +129,7 @@
                 <item name="CaptureMode" xsi:type="object">Mollie\Payment\Service\Order\TransactionPart\CaptureMode</item>
                 <item name="terminalId" xsi:type="object">Mollie\Payment\Service\Order\TransactionPart\TerminalId</item>
                 <item name="LimitStreetLength" xsi:type="object">Mollie\Payment\Service\Order\TransactionPart\LimitStreetLength</item>
+                <item name="LimitedMethods" xsi:type="object">Mollie\Payment\Service\Order\TransactionPart\LimitedMethods</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...