### PR TITLE
Add the order currency to the PDF totals

### DIFF
--- a/Model/PaymentFee/Order/Pdf/Total/PaymentFee.php
+++ b/Model/PaymentFee/Order/Pdf/Total/PaymentFee.php
@@ -38,7 +38,8 @@ class PaymentFee extends DefaultTotal
     public function getTotalsForDisplay()
     {
         $source = $this->getSource();
-        $amount = $source->getMolliePaymentFee() + $source->getMolliePaymentFeeTax();
+        $sourceDataCurrency = $source->getData('order_currency_code');
+        $amount = $source->getMolliePaymentFee();
 
         if (!$amount) {
             return [];
@@ -46,7 +47,13 @@ class PaymentFee extends DefaultTotal
 
         return [
             [
-                'amount' => $this->currency->format($amount, false),
+                'amount' => $this->currency->format(
+                    $amount,
+                    false,
+                    \Magento\Framework\Pricing\PriceCurrencyInterface::DEFAULT_PRECISION,
+                    null,
+                    $sourceDataCurrency
+                ),
                 'label' => __('Payment Fee'),
                 'font_size' => $this->getFontSize() ? $this->getFontSize() : 7,
             ],


### PR DESCRIPTION
Make sure that the order currency is being used instead of the base currency when rendering PDF's

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Backend*
- [ ] PDF order totals

*Order Processing (Mollie communication)*
- [ ] Invoicing the order

**Other**

**Please describe the bug/feature/etc this PR contains:**

https://github.com/mollie/magento2/issues/919

**Scenario**

Pull the changes and observe the PDF totals using the correct order currency symbols. See the link to the issue for more detailed information.