### PR TITLE
[PIMAG-807] Feature: Add the PayPal reference to the transactions grid

### DIFF
--- a/Block/Adminhtml/Widget/Grid/PaypalReferenceColumn.php
+++ b/Block/Adminhtml/Widget/Grid/PaypalReferenceColumn.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Block\Adminhtml\Widget\Grid;
+
+use Magento\Backend\Block\Widget\Grid\Column;
+use Magento\Sales\Api\Data\TransactionInterface;
+use Magento\Sales\Model\ResourceModel\Transaction\Grid\Collection;
+
+class PaypalReferenceColumn extends Column
+{
+    public function _construct()
+    {
+        parent::_construct();
+
+        $this->setData(
+            'filter_condition_callback',
+            [$this, 'filterPaypalReference']
+        );
+    }
+
+    public function getFrameCallback(): array
+    {
+        return [$this, 'decorate'];
+    }
+
+    public function decorate($value, TransactionInterface $row): string
+    {
+        $information = $row->getData('additional_information');
+        if (!array_key_exists('details', $information)) {
+            return '';
+        }
+
+        $details = json_decode($information['details'], true);
+        if (!array_key_exists('paypalReference', $details)) {
+            return '';
+        }
+
+        return $details['paypalReference'];
+    }
+
+    public function filterPaypalReference(Collection $collection, self $column)
+    {
+        if (!$this->getFilter()->getValue()) {
+            return;
+        }
+
+        $value = $this->getFilter()->getValue();
+        $collection->addFieldToFilter('sop.additional_information', ['like' => '%' . $value . '%']);
+    }
+}

--- a/Observer/BackendBlockWidgetGridPrepareGridBefore/AddAdditionalInformationToCollection.php
+++ b/Observer/BackendBlockWidgetGridPrepareGridBefore/AddAdditionalInformationToCollection.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Observer\BackendBlockWidgetGridPrepareGridBefore;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\ResourceModel\Order\Payment\Transaction\Collection;
+
+class AddAdditionalInformationToCollection implements ObserverInterface
+{
+    public function execute(Observer $observer)
+    {
+        $collection = $observer->getEvent()->getCollection();
+
+        if (!$collection instanceof Collection) {
+            return;
+        }
+
+        $collection->addPaymentInformation(['sop.additional_information']);
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -80,4 +80,7 @@
     <event name="adminhtml_sales_order_create_process_item_before">
         <observer name="mollie_set_purchase_type_on_create_order_item" instance="Mollie\Payment\Observer\AdminhtmlSalesOrderCreateProcessItemBefore\SetPurchaseTypeOnCreateOrderItem" />
     </event>
+    <event name="backend_block_widget_grid_prepare_grid_before">
+        <observer name="mollie_add_additional_data_to_collection" instance="Mollie\Payment\Observer\BackendBlockWidgetGridPrepareGridBefore\AddAdditionalInformationToCollection" />
+    </event>
 </config>

--- a/view/adminhtml/layout/sales_transactions_grid_block.xml
+++ b/view/adminhtml/layout/sales_transactions_grid_block.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Magmodules.eu. All rights reserved.
+  ~ See COPYING.txt for license details.
+  -->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="sales.transactions.grid.columnSet">
+            <block class="Mollie\Payment\Block\Adminhtml\Widget\Grid\PaypalReferenceColumn" name="mollie_paypal_reference">
+                <arguments>
+                    <argument name="header" xsi:type="string" translate="true">Mollie PayPal ID</argument>
+                    <argument name="type" xsi:type="string">additional_information_renderer</argument>
+                    <argument name="index" xsi:type="string">additional_information</argument>
+                    <argument name="id" xsi:type="string">additional_information</argument>
+                    <argument name="header_css_class" xsi:type="string">col-id</argument>
+                    <argument name="column_css_class" xsi:type="string">col-id</argument>
+                </arguments>
+            </block>
+        </referenceBlock>
+    </body>
+</page>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...