### PR TITLE
Bugfix: Return reward points when the order gets cancelled #928

### DIFF
--- a/Service/Magento/Order/CancelRewardPoints.php
+++ b/Service/Magento/Order/CancelRewardPoints.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Service\Magento\Order;
+
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Module\Manager;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Reward\Observer\ReturnRewardPoints;
+use Magento\Sales\Api\Data\OrderInterface;
+
+class CancelRewardPoints
+{
+    /**
+     * @var Manager
+     */
+    private $moduleManager;
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    public function __construct(
+        Manager $moduleManager,
+        ObjectManagerInterface $objectManager,
+    ) {
+        $this->moduleManager = $moduleManager;
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Magento Reward point has an even to listen for canceled orders, but this is only active in the adminhtml area.
+     * So mock the event so that the reward points get returned when the order gets canceled in the frontend.
+     */
+    public function execute(OrderInterface $order): void
+    {
+        if (!$this->moduleManager->isEnabled('Magento_Reward')) {
+            return;
+        }
+
+        $data = ['order' => $order];
+        $eventName = 'order_cancel_after';
+
+        // Magento doesn't use factories so neither are we. Plus, using factories gives dependency issues.
+        $event = new Event($data);
+        $event->setName($eventName);
+
+        $wrapper = new Observer();
+        $wrapper->setData(array_merge(['event' => $event], $data));
+
+        $instance = $this->objectManager->create(ReturnRewardPoints::class);
+        $instance->execute($wrapper);
+    }
+}

--- a/Service/Order/CancelOrder.php
+++ b/Service/Order/CancelOrder.php
@@ -13,6 +13,7 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\StatusResolver;
 use Mollie\Payment\Config;
+use Mollie\Payment\Service\Magento\Order\CancelRewardPoints;
 
 class CancelOrder
 {
@@ -20,6 +21,11 @@ class CancelOrder
      * @var Config
      */
     private $config;
+
+    /**
+     * @var CancelRewardPoints
+     */
+    private $cancelRewardPoints;
 
     /**
      * @var OrderCommentHistory
@@ -40,7 +46,6 @@ class CancelOrder
      * @var StatusResolver
      */
     private $statusResolver;
-
     /**
      * @var ResourceConnection
      */
@@ -48,13 +53,16 @@ class CancelOrder
 
     public function __construct(
         Config $config,
+        CancelRewardPoints $cancelRewardPoints,
         OrderCommentHistory $orderCommentHistory,
         OrderManagementInterface $orderManagement,
         OrderRepositoryInterface $orderRepository,
         StatusResolver $statusResolver,
         ResourceConnection $resource
-    ) {
+    )
+    {
         $this->config = $config;
+        $this->cancelRewardPoints = $cancelRewardPoints;
         $this->orderCommentHistory = $orderCommentHistory;
         $this->orderManagement = $orderManagement;
         $this->orderRepository = $orderRepository;
@@ -84,6 +92,7 @@ class CancelOrder
         $this->orderRepository->save($order);
 
         $this->orderManagement->cancel($order->getId());
+        $this->cancelRewardPoints->execute($order);
 
         return true;
     }


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...