### PR TITLE
Fix: Magento can't handle the 'self' argument type

### DIFF
--- a/Block/Adminhtml/Widget/Grid/PaypalReferenceColumn.php
+++ b/Block/Adminhtml/Widget/Grid/PaypalReferenceColumn.php
@@ -44,7 +44,7 @@ class PaypalReferenceColumn extends Column
         return $details['paypalReference'];
     }
 
-    public function filterPaypalReference(Collection $collection, self $column)
+    public function filterPaypalReference(Collection $collection, Column $column)
     {
         if (!$this->getFilter()->getValue()) {
             return;


### PR DESCRIPTION
CLI `bin/magento setup:di:compile` will create the Interceptor, but Magento throws an exception when generating it on-the-fly (in Developer mode).

See issue #937 