### PR TITLE
Prevent successful virtual Mollie orders being auto-cancelled after X hours

### DIFF
--- a/Model/Client/Orders/Processors/SuccessfulPayment.php
+++ b/Model/Client/Orders/Processors/SuccessfulPayment.php
@@ -270,8 +270,7 @@ class SuccessfulPayment implements OrderProcessorInterface
     private function setOrderStatus($order): void
     {
         $defaultStatusProcessing = $this->mollieHelper->getStatusProcessing($order->getStoreId());
-        if (!$order->getIsVirtual() &&
-            $defaultStatusProcessing &&
+        if ($defaultStatusProcessing &&
             $defaultStatusProcessing != $order->getStatus()
         ) {
             $order->setStatus($defaultStatusProcessing);

--- a/Model/Client/Payments/Processors/SuccessfulPayment.php
+++ b/Model/Client/Payments/Processors/SuccessfulPayment.php
@@ -200,11 +200,9 @@ class SuccessfulPayment implements PaymentProcessorInterface
             }
         }
 
-        if (!$magentoOrder->getIsVirtual()) {
-            $defaultStatusProcessing = $this->mollieHelper->getStatusProcessing($magentoOrder->getStoreId());
-            if ($defaultStatusProcessing && ($defaultStatusProcessing != $magentoOrder->getStatus())) {
-                $magentoOrder->setStatus($defaultStatusProcessing);
-            }
+        $defaultStatusProcessing = $this->mollieHelper->getStatusProcessing($magentoOrder->getStoreId());
+        if ($defaultStatusProcessing && ($defaultStatusProcessing != $magentoOrder->getStatus())) {
+            $magentoOrder->setStatus($defaultStatusProcessing);
         }
 
         $this->orderRepository->save($magentoOrder);


### PR DESCRIPTION
## Summary
  This PR fixes an issue where successful Mollie transactions for virtual-product orders remain in Magento status `pending_payment`. Because Magento’s core cron cancels orders with status `pending_payment` after `sales/orders/
  delete_pending_after` minutes, these orders get cancelled later even though Mollie has already authorized/paid them. When Magento cancels the order, Mollie’s observer cancels the corresponding Mollie order via the Mollie API, which is why we see Mollie orders being cancelled “after X hours”.

  ## What happens today (why this is a problem)
  1) Customer places an order containing only virtual items (is_virtual=1).
  2) Mollie transaction succeeds (paid/authorized). Mollie webhook triggers our integration (webhook -> queue consumer).
  3) Mollie processing sets the Magento order state to `processing`, but the Magento order status stays `pending_payment` for virtual orders.
  4) Magento cron `Magento\Sales\Model\CronJob\CleanExpiredOrders` cancels orders with status `pending_payment` once `updated_at` is older than `sales/orders/delete_pending_after`.
  5) On cancel, Mollie’s `order_cancel_after` observer calls Mollie’s cancel endpoint, so the Mollie order/payment is cancelled as a direct consequence of Magento’s auto-cancel.

  This matches the real-world symptom: virtual orders are cancelled in Mollie after X hours.

  ## Root cause
  In Mollie’s success processors, the code that updates the order status to the configured “processing” status is guarded by `!$order->getIsVirtual()`. That means:
  - physical/mixed orders: status is updated to `payment/mollie_general/order_status_processing` (default: `processing`)
  - virtual-only orders: status update is skipped and stays `pending_payment`

  As a result, virtual-only orders keep looking like “pending payment” to Magento’s expiration cron, even after a successful Mollie webhook.

  ## Fix (what this PR changes)
  After this change, successful transactions update the Magento order status to the configured processing status for virtual orders as well. This prevents Magento’s core “delete pending orders” cron from cancelling them later.

  ## Why this is safe / intended
  - Mollie already sets the order *state* to `processing` on success. This patch only aligns the *status* with that state.
  - The status used is still configurable via Mollie’s config (`payment/mollie_general/order_status_processing`), so we do not hardcode anything.

  ## How to test / verify (please confirm)
  1) Place a virtual-product order using Mollie (any method that goes through webhooks/queue).
  2) Wait for Mollie webhook processing / queue consumer to finish.
  3) Verify in Magento admin (or DB) that the order is NOT `status=pending_payment` anymore, but `status=<configured processing status>` (default: `processing`).
  4) Wait/run the Sales “clean expired orders” cron after your configured lifetime and confirm the order is NOT auto-cancelled.
  5) Confirm the Mollie order is not cancelled later “after X hours”.

  If you can, please also verify one non-virtual Mollie order to ensure behaviour is unchanged there.