### PR TITLE
[PIMAG-865] Improvement: Send the full address for payments api transactions

### DIFF
--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -202,10 +202,10 @@ class Payments extends AbstractModel
 
     /**
      * @param OrderInterface $order
-     * @param \Mollie\Api\MollieApiClient $mollieApi
+     * @param MollieApiClient $mollieApi
      *
      * @return string
-     * @throws \Mollie\Api\Exceptions\ApiException
+     * @throws ApiException
      */
     public function startTransaction(OrderInterface $order, $mollieApi)
     {
@@ -267,6 +267,8 @@ class Payments extends AbstractModel
 
     public function getAddressLine(OrderAddressInterface $address): array
     {
+        // Phone is added in \Mollie\Payment\Service\Order\TransactionPart\PhoneNumber
+
         $output = [
             'givenName' => $address->getFirstname(),
             'familyName' => $address->getLastname(),
@@ -277,7 +279,6 @@ class Payments extends AbstractModel
             'region' => $address->getRegion(),
             'country' => $address->getCountryId(),
             'email' => $address->getEmail(),
-            'telephone' => $address->getTelephone(),
         ];
 
         if ($address->getAddressType() == Address::TYPE_BILLING) {
@@ -336,13 +337,13 @@ class Payments extends AbstractModel
 
     /**
      * @param Order                       $order
-     * @param \Mollie\Api\MollieApiClient $mollieApi
+     * @param MollieApiClient $mollieApi
      * @param string                      $type
      * @param null                        $paymentToken
      *
      * @return array
      * @throws LocalizedException
-     * @throws \Mollie\Api\Exceptions\ApiException
+     * @throws ApiException
      */
     public function processTransaction(Order $order, $mollieApi, $type = 'webhook', $paymentToken = null)
     {

--- a/Model/Client/Payments.php
+++ b/Model/Client/Payments.php
@@ -15,6 +15,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Address;
 use Magento\Sales\Model\OrderRepository;
+use Mollie\Api\Exceptions\ApiException;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment as MolliePayment;
 use Mollie\Api\Types\PaymentStatus;
@@ -267,12 +268,16 @@ class Payments extends AbstractModel
     public function getAddressLine(OrderAddressInterface $address): array
     {
         $output = [
+            'givenName' => $address->getFirstname(),
+            'familyName' => $address->getLastname(),
+            'organizationName' => $address->getCompany(),
             'streetAndNumber' => rtrim(implode(' ', $address->getStreet()), ' '),
             'postalCode' => $address->getPostcode(),
             'city' => $address->getCity(),
             'region' => $address->getRegion(),
             'country' => $address->getCountryId(),
             'email' => $address->getEmail(),
+            'telephone' => $address->getTelephone(),
         ];
 
         if ($address->getAddressType() == Address::TYPE_BILLING) {

--- a/Service/Order/TransactionPart/PhoneNumber.php
+++ b/Service/Order/TransactionPart/PhoneNumber.php
@@ -2,9 +2,9 @@
 
 namespace Mollie\Payment\Service\Order\TransactionPart;
 
+use InvalidArgumentException;
+use Magento\Sales\Api\Data\OrderAddressInterface;
 use Magento\Sales\Api\Data\OrderInterface;
-use Mollie\Payment\Model\Client\Payments;
-use Mollie\Payment\Model\Methods\In3;
 use Mollie\Payment\Service\Order\TransactionPartInterface;
 
 class PhoneNumber implements TransactionPartInterface
@@ -261,35 +261,43 @@ class PhoneNumber implements TransactionPartInterface
 
     public function process(OrderInterface $order, $apiMethod, array $transaction)
     {
-        if ($order->getPayment()->getMethod() != In3::CODE) {
-            return $transaction;
-        }
+        $transaction['billingAddress'] = $this->formatForAddress(
+            $order->getBillingAddress(),
+            $transaction['billingAddress'],
+        );
 
-        if ($apiMethod == Payments::CHECKOUT_TYPE) {
-            return $transaction;
-        }
+        $transaction['shippingAddress'] = $this->formatForAddress(
+            $order->getShippingAddress(),
+            $transaction['shippingAddress'],
+        );
 
-        $address = $order->getBillingAddress();
+        return $transaction;
+    }
+
+    private function formatForAddress(OrderAddressInterface $address, array $transactionAddress): array
+    {
         $countryCode = $address->getCountryId();
         $phoneNumber = $address->getTelephone();
 
-        if (empty($phoneNumber)) {
-            return $transaction;
+        if (!$countryCode || !$phoneNumber) {
+            return $transactionAddress;
         }
 
         try {
-            $transaction['billingAddress']['phone'] = $this->formatInE164($countryCode, $phoneNumber);
-        } catch (\InvalidArgumentException $exception) {
+            $transactionAddress['phone'] = $this->formatInE164($countryCode, $phoneNumber);
+
+            return $transactionAddress;
+        } catch (InvalidArgumentException $exception) {
             // Silently ignore the exception
         }
 
-        return $transaction;
+        return $transactionAddress;
     }
 
     private function formatInE164(string $countryCodeIso2, string $phoneNumber): string
     {
         if (!array_key_exists($countryCodeIso2, self::COUNTRY_CODE_MAPPING)) {
-            throw new \InvalidArgumentException(sprintf('Country code "%s" is not supported', $countryCodeIso2));
+            throw new InvalidArgumentException(sprintf('Country code "%s" is not supported', $countryCodeIso2));
         }
 
         $countryCode = self::COUNTRY_CODE_MAPPING[$countryCodeIso2];
@@ -306,7 +314,7 @@ class PhoneNumber implements TransactionPartInterface
         $formattedNumber = '+' . $countryCode . $formattedNumber;
 
         if (strlen($formattedNumber) <= 3 || !preg_match('/^\+[1-9]\d{1,14}$/', $formattedNumber)) {
-            throw new \InvalidArgumentException(__('Phone number "%s" is not valid', $formattedNumber));
+            throw new InvalidArgumentException(__('Phone number "%s" is not valid', $formattedNumber));
         }
 
         return $formattedNumber;

--- a/Test/Integration/Service/Order/TransactionPart/PhoneNumberTest.php
+++ b/Test/Integration/Service/Order/TransactionPart/PhoneNumberTest.php
@@ -3,53 +3,13 @@
 namespace Mollie\Payment\Test\Integration\Service\Order\TransactionPart;
 
 use Magento\Sales\Api\Data\OrderAddressInterface;
-use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Mollie\Payment\Model\Client\Orders;
-use Mollie\Payment\Model\Client\Payments;
 use Mollie\Payment\Service\Order\TransactionPart\PhoneNumber;
 use Mollie\Payment\Test\Integration\IntegrationTestCase;
 
 class PhoneNumberTest extends IntegrationTestCase
 {
-    public function testDoesNothingWhenPaymentMethodIsNotIn3(): void
-    {
-        /** @var PhoneNumber $instance */
-        $instance = $this->objectManager->create(PhoneNumber::class);
-
-        $order = $this->objectManager->create(OrderInterface::class);
-        $order->setPayment($this->objectManager->create(OrderPaymentInterface::class));
-        $order->getPayment()->setMethod('mollie_methods_ideal');
-
-        $transaction = $instance->process(
-            $order,
-            Payments::CHECKOUT_TYPE,
-            ['billingAddress' => []]
-        );
-
-        $this->assertArrayNotHasKey('phone', $transaction['billingAddress']);
-    }
-
-    public function testDoesNothingWhenPaymentsApiIsUsed(): void
-    {
-        $transaction = [];
-
-        /** @var PhoneNumber $instance */
-        $instance = $this->objectManager->create(PhoneNumber::class);
-
-        $order = $this->objectManager->create(OrderInterface::class);
-        $order->setPayment($this->objectManager->create(OrderPaymentInterface::class));
-        $order->getPayment()->setMethod('mollie_methods_in3');
-
-        $newTransaction = $instance->process(
-            $order,
-            Payments::CHECKOUT_TYPE,
-            $transaction
-        );
-
-        $this->assertSame($transaction, $newTransaction);
-    }
-
     /**
      * @magentoDataFixture Magento/Sales/_files/order.php
      * @dataProvider convertsPhoneNumbersToTheCorrectFormatDataProvider
@@ -77,7 +37,7 @@ class PhoneNumberTest extends IntegrationTestCase
         $transaction = $instance->process(
             $order,
             Orders::CHECKOUT_TYPE,
-            ['billingAddress' => []]
+            ['billingAddress' => [], 'shippingAddress' => []]
         );
 
         $this->assertSame($expected, $transaction['billingAddress']['phone']);
@@ -103,7 +63,7 @@ class PhoneNumberTest extends IntegrationTestCase
         $transaction = $instance->process(
             $order,
             Orders::CHECKOUT_TYPE,
-            ['billingAddress' => []]
+            ['billingAddress' => [], 'shippingAddress' => []]
         );
 
         $this->assertArrayNotHasKey('phone', $transaction['billingAddress']);
@@ -129,7 +89,7 @@ class PhoneNumberTest extends IntegrationTestCase
         $transaction = $instance->process(
             $order,
             Orders::CHECKOUT_TYPE,
-            ['billingAddress' => []]
+            ['billingAddress' => [], 'shippingAddress' => []]
         );
 
         $this->assertArrayNotHasKey('phone', $transaction['billingAddress']);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...