### PR TITLE
Fix creditmemo crash when Mollie payment details are stored as plain …

### DIFF
--- a/Service/Mollie/Order/ParseAdditionalData.php
+++ b/Service/Mollie/Order/ParseAdditionalData.php
@@ -71,9 +71,20 @@ class ParseAdditionalData
     public function getDetails(OrderPaymentInterface $payment): ?Details
     {
         $details = $payment->getAdditionalInformation('details');
-        if ($this->config->encryptPaymentDetails()) {
-            $details = $this->encryptor->decrypt($details);
-        }
+
+ 	if ($this->config->encryptPaymentDetails() && is_string($details) && $details !== '') {
+     	    $trimmed = ltrim($details);
+     	    $looksLikeJson = ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '['));
+
+     	    if (!$looksLikeJson) {
+         	try {
+             	    $details = $this->encryptor->decrypt($details);
+          	} catch (\Exception $e) {
+              	    // Keep original value when decryption fails
+          	}
+      	    }
+  	}
+
         if (is_string($details)) {
             $details = json_decode($details, true);
         }


### PR DESCRIPTION
…JSON

Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [x] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [x] Refunding (credit memo) the order

**Other**
N/A

**Please describe the bug/feature/etc this PR contains:**

When creating a credit memo for older Mollie orders, Magento can throw:
`Magento\Framework\Exception\LocalizedException: Init vector must be a string of 32 bytes`.

Root cause: older orders may store `sales_order_payment.additional_information['details']` as plain JSON, while newer module versions attempt to decrypt this value when payment detail encryption is enabled.

This PR adds a backwards-compatible fallback: detect JSON-like values and only call `decrypt()` when the value does not look like JSON. If decryption fails, the original value is kept so the admin flow does not crash.

**Scenario to test this code:**

1. Use a Magento 2 shop with Mollie installed.
2. Ensure Mollie setting “encrypt payment details” is enabled.
3. Have at least one *older* Mollie order where `additional_information['details']` is stored as plain JSON (legacy data).
4. In the Magento Admin go to **Sales → Orders**, open that older Mollie order.
5. Click **Credit Memo**.
6. Expected: the credit memo page loads without errors and refund can be created.

(Optional) Verify that newer orders (where details are encrypted) still behave as before.
