### PR TITLE
PIMAG-920 - Bugfix: Copy the items from the original order when reordering #968

### DIFF
--- a/Service/Order/CopyOriginalOrderItemData.php
+++ b/Service/Order/CopyOriginalOrderItemData.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Service\Order;
+
+use Magento\Framework\DataObject\Copy;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+
+class CopyOriginalOrderItemData
+{
+    /**
+     * @var Copy
+     */
+    private $objectCopyService;
+
+    public function __construct(
+        Copy $objectCopyService
+    ) {
+        $this->objectCopyService = $objectCopyService;
+    }
+
+    public function execute(OrderInterface $originalOrder, CartInterface $quote): void
+    {
+        $orderItemMap = [];
+        foreach ($originalOrder->getItems() as $orderItem) {
+            if ($orderItem->getParentItemId()) {
+                continue;
+            }
+
+            $key = $orderItem->getProductId() . ':' . $orderItem->getSku();
+            $orderItemMap[$key] = $orderItem;
+        }
+
+        foreach ($quote->getAllVisibleItems() as $quoteItem) {
+            $key = $quoteItem->getProductId() . ':' . $quoteItem->getSku();
+            if (!isset($orderItemMap[$key])) {
+                continue;
+            }
+
+            $this->objectCopyService->copyFieldsetToTarget(
+                'sales_convert_order_item',
+                'to_quote_item',
+                $orderItemMap[$key],
+                $quoteItem
+            );
+        }
+
+        $quote->setTotalsCollectedFlag(false);
+        $quote->collectTotals();
+    }
+}

--- a/Service/Order/Reorder.php
+++ b/Service/Order/Reorder.php
@@ -79,6 +79,11 @@ class Reorder
      */
     private $shouldEmailInvoice;
 
+    /**
+     * @var CopyOriginalOrderItemData
+     */
+    private $copyOriginalOrderItemData;
+
     public function __construct(
         Config $config,
         Create $orderCreate,
@@ -89,7 +94,8 @@ class Reorder
         Session $checkoutSession,
         Product $productHelper,
         DisableCheckForAdminOrders $disableCheckForAdminOrders,
-        ShouldEmailInvoice $shouldEmailInvoice
+        ShouldEmailInvoice $shouldEmailInvoice,
+        CopyOriginalOrderItemData $copyOriginalOrderItemData
     ) {
         $this->config = $config;
         $this->orderCreate = $orderCreate;
@@ -101,6 +107,7 @@ class Reorder
         $this->productHelper = $productHelper;
         $this->disableCheckForAdminOrders = $disableCheckForAdminOrders;
         $this->shouldEmailInvoice = $shouldEmailInvoice;
+        $this->copyOriginalOrderItemData = $copyOriginalOrderItemData;
     }
 
     public function create(OrderInterface $originalOrder): OrderInterface
@@ -174,6 +181,7 @@ class Reorder
         $this->productHelper->setSkipSaleableCheck(true);
         $this->orderCreate->setData('account', ['email' => $originalOrder->getCustomerEmail()]);
         $this->orderCreate->initFromOrder($originalOrder);
+        $this->copyOriginalOrderItemData->execute($originalOrder, $this->orderCreate->getQuote());
 
         $customerGroupId = $originalOrder->getCustomerGroupId() ?? 0;
         $this->orderCreate->getQuote()->getCustomer()->setGroupId($customerGroupId);

--- a/Test/Integration/Service/Order/ReorderTest.php
+++ b/Test/Integration/Service/Order/ReorderTest.php
@@ -1,0 +1,148 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Mollie\Payment\Test\Integration\Service\Order;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Mollie\Payment\Service\Order\CopyOriginalOrderItemData;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class ReorderTest extends IntegrationTestCase
+{
+    /**
+     * @var CopyOriginalOrderItemData
+     */
+    private $instance;
+
+    protected function setUpWithoutVoid()
+    {
+        $this->instance = $this->objectManager->create(CopyOriginalOrderItemData::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCopiesCustomPriceFromOrderItemToQuoteItem()
+    {
+        $order = $this->loadOrderById('100000001');
+        $quote = $this->createQuoteFromOrder($order);
+
+        $this->instance->execute($order, $quote);
+
+        $quoteItem = $this->getFirstVisibleItem($quote);
+        $orderItem = $this->getFirstItem($order);
+
+        $this->assertEquals(
+            $orderItem->getPrice(),
+            $quoteItem->getCustomPrice(),
+            'The custom price on the quote item should match the original order item price'
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCustomPriceIsSetOnQuoteItem()
+    {
+        $order = $this->loadOrderById('100000001');
+        $quote = $this->createQuoteFromOrder($order);
+
+        // Before: quote item should not have a custom price
+        $quoteItemBefore = $this->getFirstVisibleItem($quote);
+        $this->assertNull($quoteItemBefore->getCustomPrice(), 'Quote item should not have a custom price before copy');
+
+        $this->instance->execute($order, $quote);
+
+        $quoteItemAfter = $this->getFirstVisibleItem($quote);
+        $orderItem = $this->getFirstItem($order);
+
+        $this->assertNotNull($quoteItemAfter->getCustomPrice(), 'Quote item should have a custom price after copy');
+        $this->assertEquals(
+            $orderItem->getPrice(),
+            $quoteItemAfter->getCustomPrice(),
+            'The custom price should be set to the original order item price'
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testSkipsChildItems()
+    {
+        $order = $this->loadOrderById('100000001');
+        $parentItem = $this->getFirstItem($order);
+
+        $childItem = $this->objectManager->create(OrderItemInterface::class);
+        $childItem->setProductId($parentItem->getProductId());
+        $childItem->setSku($parentItem->getSku());
+        $childItem->setParentItemId($parentItem->getItemId());
+        $childItem->setPrice(999);
+        $order->addItem($childItem);
+
+        $quote = $this->createQuoteFromOrder($order);
+
+        $this->instance->execute($order, $quote);
+
+        $quoteItem = $this->getFirstVisibleItem($quote);
+
+        $this->assertEquals(
+            $parentItem->getPrice(),
+            $quoteItem->getCustomPrice(),
+            'Only parent order items should be matched to quote items'
+        );
+    }
+
+    private function createQuoteFromOrder(OrderInterface $order): CartInterface
+    {
+        $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+
+        /** @var Quote $quote */
+        $quote = $this->objectManager->create(Quote::class);
+        $quote->setStoreId($order->getStoreId());
+
+        foreach ($order->getItems() as $orderItem) {
+            if ($orderItem->getParentItemId()) {
+                continue;
+            }
+
+            $product = $productRepository->getById($orderItem->getProductId());
+
+            try {
+                $quote->addProduct($product, $orderItem->getQtyOrdered());
+            } catch (LocalizedException $e) {
+                // This only happens in the "with-replacements" variants
+                $this->markTestSkipped('Product is not available: ' . $e->getMessage());
+            }
+        }
+
+        $quote->collectTotals();
+
+        return $quote;
+    }
+
+    private function getFirstItem(OrderInterface $order)
+    {
+        foreach ($order->getItems() as $item) {
+            if (!$item->getParentItemId()) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function getFirstVisibleItem(CartInterface $quote)
+    {
+        $items = $quote->getAllVisibleItems();
+
+        return reset($items);
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...