### PR TITLE
Bugfix: Fallback on order transaction id

### DIFF
--- a/Service/Mollie/Order/GetTransactionId.php
+++ b/Service/Mollie/Order/GetTransactionId.php
@@ -63,11 +63,11 @@ class GetTransactionId
         }, $this->transactionToOrderManagement->getForOrder((int)$order->getEntityId()));
 
         if (!$transactions) {
-            return null;
+            return $order->getMollieTransactionId();
         }
 
         if (count($transactions) === 1) {
-            return $order->getMollieTransactionId();
+            return reset($transactions);
         }
 
         $this->config->addToLog('warning', [

--- a/Test/Integration/Service/Mollie/Order/GetTransactionIdTest.php
+++ b/Test/Integration/Service/Mollie/Order/GetTransactionIdTest.php
@@ -22,17 +22,29 @@ class GetTransactionIdTest extends IntegrationTestCase
      * @magentoDataFixture Magento/Sales/_files/order.php
      * @return void
      */
-    public function testDoesNothingWhenNoTransactionIsAvailable(): void
+    public function testReturnsNullWhenNoTransactionIsAvailableAnywhere(): void
     {
         $order = $this->loadOrderById('100000001');
 
         $instance = $this->objectManager->create(GetTransactionId::class);
-        $instance->forOrder($order);
+        $result = $instance->forOrder($order);
 
-        $this->assertNull(
-            $order->getMollieTransactionId(),
-            'Transaction ID should not be set when no transaction is available'
-        );
+        $this->assertNull($result);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @return void
+     */
+    public function testFallsBackToOrderEntityWhenNotInTransactionTable(): void
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->setMollieTransactionId('tr_abc123');
+
+        $instance = $this->objectManager->create(GetTransactionId::class);
+        $result = $instance->forOrder($order);
+
+        $this->assertEquals('tr_abc123', $result);
     }
 
     /**


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...