### PR TITLE
fix: catch invalid return values

### DIFF
--- a/Observer/SalesQuoteItemSetProduct/SetSubscriptionDataOnBuyRequest.php
+++ b/Observer/SalesQuoteItemSetProduct/SetSubscriptionDataOnBuyRequest.php
@@ -45,6 +45,10 @@ class SetSubscriptionDataOnBuyRequest implements ObserverInterface
         $data = $this->serializer->unserialize($table);
         $default = $this->getDefault($data);
 
+        if (!is_array($default) || !is_scalar($default['identifier'] ?? null)) {
+            return;
+        }
+
         $value['mollie_metadata'] = [
             'purchase' => 'subscription',
             'recurring_metadata' => [
@@ -55,15 +59,17 @@ class SetSubscriptionDataOnBuyRequest implements ObserverInterface
         $buyRequest->setValue($this->serializer->serialize($value));
     }
 
-    private function getDefault(array $data): array
+    private function getDefault(array $data): ?array
     {
         foreach ($data as $row) {
-            if (isset($row['isDefault']) && $row['isDefault']) {
+            if (is_array($row) && isset($row['isDefault']) && $row['isDefault']) {
                 return $row;
             }
         }
 
-        return array_shift($data);
+        $default = array_shift($data);
+
+        return is_array($default) ? $default : null;
     }
 
     private function getBuyRequest(CartItemInterface $item): OptionInterface


### PR DESCRIPTION
In case if `mollie_subscription_table` is not maintained within the product, there is also no defined `default`. 
the changed observer would break with the fatal error message:

> TypeError: Mollie\Payment\Observer\SalesQuoteItemSetProduct\SetSubscriptionDataOnBuyRequest::getDefault(): Return value must be of type array, null returned in /var/www/html/project/vendor/mollie/magento2/Observer/SalesQuoteItemSetProduct/SetSubscriptionDataOnBuyRequest.php:69

this change allows to return null and also catches non-array-values. 

---

Notice: it would be better, if this is part of the module `mollie/magento2-subscriptions`. 
So the Helper `Mollie\Subscriptions\Service\Mollie\ParseSubscriptionOptions` could be used.