### PR TITLE
Bugfix: Set the customer name from the billing address for Apple Pay orders #992

### DIFF
--- a/Controller/ApplePay/PlaceOrder.php
+++ b/Controller/ApplePay/PlaceOrder.php
@@ -105,10 +105,15 @@ class PlaceOrder extends Action
         $cart = $this->getCart();
 
         $shippingAddress = $cart->getShippingAddress();
-        $this->updateAddress($shippingAddress, $this->getRequest()->getParam('shippingAddress'));
-        $this->updateAddress($cart->getBillingAddress(), $this->getRequest()->getParam('billingAddress'));
+        $shippingAddressData = $this->getRequest()->getParam('shippingAddress');
+        $billingAddressData = $this->getRequest()->getParam('billingAddress');
 
-        $cart->setCustomerEmail($this->getRequest()->getParam('shippingAddress')['emailAddress']);
+        $this->updateAddress($shippingAddress, $shippingAddressData);
+        $this->updateAddress($cart->getBillingAddress(), $billingAddressData);
+
+        $cart->setCustomerFirstname($billingAddressData['givenName'] ?? $shippingAddressData['givenName'] ?? '');
+        $cart->setCustomerLastname($billingAddressData['familyName'] ?? $shippingAddressData['familyName'] ?? '--');
+        $cart->setCustomerEmail($billingAddressData['emailAddress'] ?? $shippingAddressData['emailAddress'] ?? '');
 
         // Orders with digital products can't have a shipping method
         if ($this->getRequest()->getParam('shippingMethod')) {


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...