### PR TITLE
Bugfix: Allow to refund manual capture orders

### DIFF
--- a/Model/Client/Orders/Processors/SuccessfulPayment.php
+++ b/Model/Client/Orders/Processors/SuccessfulPayment.php
@@ -173,8 +173,15 @@ class SuccessfulPayment implements OrderProcessorInterface
         $payment->setTransactionId($paymentId);
         $payment->setCurrencyCode($order->getBaseCurrencyCode());
 
-        if (!in_array($order->getState(), [MagentoOrder::STATE_PROCESSING, MagentoOrder::STATE_COMPLETE]) &&
-            $mollieOrder->isPaid()
+        $hasPendingInvoice = array_filter(
+            $order->getInvoiceCollection()->getItems(),
+            function ($invoice) {
+                return $invoice->getState() == Invoice::STATE_OPEN;
+            }
+        );
+
+        if ($mollieOrder->isPaid() &&
+            (!in_array($order->getState(), [MagentoOrder::STATE_PROCESSING, MagentoOrder::STATE_COMPLETE]) || $hasPendingInvoice)
         ) {
             $payment->setIsTransactionClosed(true);
             $payment->registerCaptureNotification($order->getBaseGrandTotal(), true);

--- a/Model/Client/Payments/CapturePayment.php
+++ b/Model/Client/Payments/CapturePayment.php
@@ -98,6 +98,7 @@ class CapturePayment
 
         $capture = $mollieApi->paymentCaptures->createForId($mollieTransactionId, $data);
         $payment->setTransactionId($capture->id);
+        $invoice->setTransactionId($mollieTransactionId);
 
         $order->addCommentToStatusHistory(
             __(

--- a/Test/Integration/Model/Client/Orders/Processors/SuccessfulPaymentTest.php
+++ b/Test/Integration/Model/Client/Orders/Processors/SuccessfulPaymentTest.php
@@ -9,6 +9,8 @@ namespace Mollie\Payment\Model\Client\Orders\Processors;
 use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Service\InvoiceService;
 use Mollie\Api\Types\OrderStatus;
 use Mollie\Payment\Test\Integration\IntegrationTestCase;
 use Mollie\Payment\Test\Integration\MollieOrderBuilder;
@@ -298,6 +300,47 @@ class SuccessfulPaymentTest extends IntegrationTestCase
         $freshOrder = $this->objectManager->get(OrderInterface::class)->load($order->getId(), 'entity_id');
 
         $this->assertEquals($historyCount + 1, count($freshOrder->getStatusHistories()));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRegistersCapturNotificationWhenOrderIsProcessingButHasPendingInvoice(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->setBaseCurrencyCode('EUR');
+        $order->setState(Order::STATE_PROCESSING);
+        $order->getPayment()->setMethod('mollie_methods_creditcard');
+        $order->getPayment()->setIsTransactionPending(true);
+
+        /** @var InvoiceService $invoiceService */
+        $invoiceService = $this->objectManager->get(InvoiceService::class);
+        $invoice = $invoiceService->prepareInvoice($order);
+        $invoice->setRequestedCaptureCase(Invoice::NOT_CAPTURE);
+        $invoice->register();
+        $invoice->save();
+
+        $order->getPayment()->setIsTransactionPending(false);
+
+        $this->assertNull($order->getTotalPaid());
+
+        /** @var MollieOrderBuilder $orderBuilder */
+        $orderBuilder = $this->objectManager->create(MollieOrderBuilder::class);
+        $orderBuilder->setAmount(100);
+        $orderBuilder->addPayment('payment_001');
+        $orderBuilder->setStatus(OrderStatus::STATUS_PAID);
+
+        /** @var SuccessfulPayment $instance */
+        $instance = $this->objectManager->create(SuccessfulPayment::class);
+
+        $instance->process(
+            $order,
+            $orderBuilder->build(),
+            'webhook',
+            $this->createResponse(false)
+        );
+
+        $this->assertEquals(100, $order->getTotalPaid());
     }
 
     private function createResponse(

--- a/Test/Integration/Model/Client/Payments/CapturePaymentTest.php
+++ b/Test/Integration/Model/Client/Payments/CapturePaymentTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Model\Client\Payments;
+
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Service\InvoiceService;
+use Mollie\Api\Endpoints\PaymentCaptureEndpoint;
+use Mollie\Api\MollieApiClient;
+use Mollie\Api\Resources\Capture;
+use Mollie\Payment\Model\Client\Payments\CapturePayment;
+use Mollie\Payment\Test\Fakes\Service\Mollie\FakeMollieApiClient;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class CapturePaymentTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testSetsTransactionIdOnInvoice(): void
+    {
+        $mollieTransactionId = 'tr_abc123';
+
+        $order = $this->loadOrder('100000001');
+        $order->setMollieTransactionId($mollieTransactionId);
+        $order->getPayment()->setIsTransactionPending(true);
+
+        /** @var InvoiceService $invoiceService */
+        $invoiceService = $this->objectManager->get(InvoiceService::class);
+        $invoice = $invoiceService->prepareInvoice($order);
+        $invoice->setRequestedCaptureCase(Invoice::NOT_CAPTURE);
+        $invoice->register();
+
+        $capture = new Capture($this->createStub(MollieApiClient::class));
+        $capture->id = 'cpt_xyz789';
+
+        $paymentCapturesStub = $this->createStub(PaymentCaptureEndpoint::class);
+        $paymentCapturesStub->method('createForId')->willReturn($capture);
+
+        $mollieApiMock = $this->createStub(MollieApiClient::class);
+        $mollieApiMock->paymentCaptures = $paymentCapturesStub;
+
+        /** @var FakeMollieApiClient $fakeMollieApiClient */
+        $fakeMollieApiClient = $this->objectManager->get(FakeMollieApiClient::class);
+        $fakeMollieApiClient->setInstance($mollieApiMock);
+        $this->objectManager->addSharedInstance($fakeMollieApiClient, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        /** @var CapturePayment $instance */
+        $instance = $this->objectManager->create(CapturePayment::class);
+        $instance->execute($invoice);
+
+        $this->assertEquals($mollieTransactionId, $invoice->getTransactionId());
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...