### PR TITLE
PIMAG-966 | Bugfix: Cast Phrase to string in PhoneNumber exception #1011

### DIFF
--- a/Service/Order/TransactionPart/PhoneNumber.php
+++ b/Service/Order/TransactionPart/PhoneNumber.php
@@ -322,7 +322,7 @@ class PhoneNumber implements TransactionPartInterface
         $formattedNumber = '+' . $countryCode . $formattedNumber;
 
         if (strlen($formattedNumber) <= 3 || !preg_match('/^\+[1-9]\d{1,14}$/', $formattedNumber)) {
-            throw new InvalidArgumentException(__('Phone number "%s" is not valid', $formattedNumber));
+            throw new InvalidArgumentException((string) __('Phone number "%s" is not valid', $formattedNumber));
         }
 
         return $formattedNumber;

--- a/Test/Integration/Service/Order/TransactionPart/PhoneNumberTest.php
+++ b/Test/Integration/Service/Order/TransactionPart/PhoneNumberTest.php
@@ -155,6 +155,39 @@ class PhoneNumberTest extends IntegrationTestCase
      * @magentoDataFixture Magento/Sales/_files/order.php
      * @return void
      */
+    public function testDoesNotThrowWhenThePhoneNumberIsInvalid(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->setPayment($this->objectManager->create(OrderPaymentInterface::class));
+        $order->getPayment()->setMethod('mollie_methods_in3');
+
+        $billingAddress = $order->getBillingAddress();
+        $billingAddress->setCountryId('NL');
+        $billingAddress->setTelephone('000');
+
+        $shippingAddress = $order->getShippingAddress();
+        $shippingAddress->setCountryId('NL');
+        $shippingAddress->setTelephone('000');
+
+        /** @var PhoneNumber $instance */
+        $instance = $this->objectManager->create(PhoneNumber::class);
+
+        $transaction = $instance->process(
+            $order,
+            [
+                'billingAddress' => [],
+                'shippingAddress' => [],
+            ],
+        );
+
+        $this->assertArrayNotHasKey('phone', $transaction['billingAddress']);
+        $this->assertArrayNotHasKey('phone', $transaction['shippingAddress']);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @return void
+     */
     public function testDoesNotOverrideExistingAddressData(): void
     {
         $order = $this->loadOrder('100000001');


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...