### PR TITLE
PIMAG-965 | Bugfix: Handle missing shipping address for virtual product orders #1010

### DIFF
--- a/Service/Mollie/BuildPaymentRequest.php
+++ b/Service/Mollie/BuildPaymentRequest.php
@@ -29,8 +29,8 @@ class BuildPaymentRequest
     public function execute(array $request): CreatePaymentRequest
     {
         $request['amount'] = $this->convertToMoney($request['amount']);
-        $request['billingAddress'] = $this->convertToAddress($request['billingAddress']);
-        $request['shippingAddress'] = $this->convertToAddress($request['shippingAddress']);
+        $request['billingAddress'] = $this->convertToAddress($request['billingAddress'] ?? []);
+        $request['shippingAddress'] = $this->convertToAddress($request['shippingAddress'] ?? []);
 
         if (array_key_exists('lines', $request)) {
             $request['lines'] = $this->dataCollectionFactory->create(['items' => $request['lines']]);

--- a/Service/Mollie/FormatExceptionMessages.php
+++ b/Service/Mollie/FormatExceptionMessages.php
@@ -36,7 +36,7 @@ class FormatExceptionMessages
 
         foreach ($this->allowedErrorMessages as $message) {
             if (stripos($exception->getMessage(), $message) !== false) {
-                return __($message);
+                return __($message)->render();
             }
         }
 

--- a/Test/Integration/Service/Mollie/BuildPaymentRequestTest.php
+++ b/Test/Integration/Service/Mollie/BuildPaymentRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie;
+
+use Mollie\Api\Http\Requests\CreatePaymentRequest;
+use Mollie\Payment\Service\Mollie\BuildPaymentRequest;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class BuildPaymentRequestTest extends IntegrationTestCase
+{
+    public function testBuildsRequestWhenShippingAddressIsMissing(): void
+    {
+        /** @var BuildPaymentRequest $instance */
+        $instance = $this->objectManager->create(BuildPaymentRequest::class);
+
+        $result = $instance->execute([
+            'description' => 'Order 0000025',
+            'amount' => ['currency' => 'EUR', 'value' => '10.00'],
+            'billingAddress' => ['email' => 'test@example.com'],
+        ]);
+
+        $this->assertInstanceOf(CreatePaymentRequest::class, $result);
+    }
+
+    public function testBuildsRequestWhenShippingAddressIsPresent(): void
+    {
+        /** @var BuildPaymentRequest $instance */
+        $instance = $this->objectManager->create(BuildPaymentRequest::class);
+
+        $result = $instance->execute([
+            'description' => 'Order 0000025',
+            'amount' => ['currency' => 'EUR', 'value' => '10.00'],
+            'billingAddress' => ['email' => 'test@example.com'],
+            'shippingAddress' => ['email' => 'test@example.com'],
+        ]);
+
+        $this->assertInstanceOf(CreatePaymentRequest::class, $result);
+    }
+}

--- a/Test/Integration/Service/Mollie/FormatExceptionMessagesTest.php
+++ b/Test/Integration/Service/Mollie/FormatExceptionMessagesTest.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie;
+
+use Exception;
+use Magento\Payment\Model\MethodInterface;
+use Mollie\Payment\Service\Mollie\FormatExceptionMessages;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class FormatExceptionMessagesTest extends IntegrationTestCase
+{
+    public function testReturnsAllowedMessageWhenItMatches(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class);
+
+        $result = $instance->execute(
+            new Exception('The billing country is not supported for this payment method.')
+        );
+
+        $this->assertSame('The billing country is not supported for this payment method.', $result);
+    }
+
+    public function testConvertsKnownMessageToExtendedVersion(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class);
+
+        $result = $instance->execute(
+            new Exception('The webhook URL is invalid because it is unreachable from Mollie\'s point of view')
+        );
+
+        $this->assertStringContainsString('github.com/mollie/magento2/wiki', $result);
+    }
+
+    public function testReturnsTimeoutMessageForCurlError28WithMethodInstance(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class);
+
+        $methodInstance = $this->createMock(MethodInterface::class);
+        $methodInstance->method('getTitle')->willReturn('iDEAL');
+
+        $result = $instance->execute(new Exception('cURL error 28: Operation timed out'), $methodInstance);
+
+        $this->assertStringContainsString('Timeout', $result);
+        $this->assertStringContainsString('iDEAL', $result);
+    }
+
+    public function testReturnsOriginalMessageForCurlError28WithoutMethodInstance(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class);
+
+        $result = $instance->execute(new Exception('cURL error 28: Operation timed out'));
+
+        $this->assertSame('cURL error 28: Operation timed out', $result);
+    }
+
+    public function testReturnsOriginalMessageForUnknownException(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class);
+
+        $result = $instance->execute(new Exception('Something completely different went wrong'));
+
+        $this->assertSame('Something completely different went wrong', $result);
+    }
+
+    public function testReturnsAllowedMessagePassedThroughConstructor(): void
+    {
+        /** @var FormatExceptionMessages $instance */
+        $instance = $this->objectManager->create(FormatExceptionMessages::class, [
+            'allowedErrorMessages' => ['A custom allowed error message.'],
+        ]);
+
+        $result = $instance->execute(new Exception('A custom allowed error message.'));
+
+        $this->assertSame('A custom allowed error message.', $result);
+    }
+}

--- a/Test/Integration/Service/Mollie/TimeoutTest.php
+++ b/Test/Integration/Service/Mollie/TimeoutTest.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie;
+
+use Exception;
+use Mollie\Payment\Service\Mollie\Timeout;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class TimeoutTest extends IntegrationTestCase
+{
+    public function testReturnsResultWhenCallbackSucceeds(): void
+    {
+        /** @var Timeout $instance */
+        $instance = $this->objectManager->create(Timeout::class);
+
+        $result = $instance->retry(fn () => 'success');
+
+        $this->assertSame('success', $result);
+    }
+
+    public function testRetriesOnTimeoutAndReturnsResultOnLaterAttempt(): void
+    {
+        /** @var Timeout $instance */
+        $instance = $this->objectManager->create(Timeout::class);
+
+        $attempts = 0;
+        $result = $instance->retry(function () use (&$attempts) {
+            $attempts++;
+            if ($attempts < 3) {
+                throw new Exception('cURL error 28: Operation timed out');
+            }
+
+            return 'success';
+        });
+
+        $this->assertSame('success', $result);
+        $this->assertSame(3, $attempts);
+    }
+
+    public function testThrowsAfterThreeTimeouts(): void
+    {
+        /** @var Timeout $instance */
+        $instance = $this->objectManager->create(Timeout::class);
+
+        $attempts = 0;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('cURL error 28');
+
+        try {
+            $instance->retry(function () use (&$attempts) {
+                $attempts++;
+                throw new Exception('cURL error 28: Operation timed out');
+            });
+        } finally {
+            $this->assertSame(3, $attempts);
+        }
+    }
+
+    public function testRethrowsNonTimeoutExceptionImmediately(): void
+    {
+        /** @var Timeout $instance */
+        $instance = $this->objectManager->create(Timeout::class);
+
+        $attempts = 0;
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Some other error');
+
+        try {
+            $instance->retry(function () use (&$attempts) {
+                $attempts++;
+                throw new Exception('Some other error');
+            });
+        } finally {
+            $this->assertSame(1, $attempts);
+        }
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...