### PR TITLE
fix: capture and sync legacy ord_ (Orders API) authorizations under v3

### DIFF
--- a/Model/Client/Payments/CapturePaymentForInvoice.php
+++ b/Model/Client/Payments/CapturePaymentForInvoice.php
@@ -12,11 +12,14 @@ use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Mollie\Api\Http\Requests\DynamicPostRequest;
 use Mollie\Payment\Helper\General;
 use Mollie\Payment\Service\Mollie\MollieApiClient;
 
 class CapturePaymentForInvoice
 {
+    private const ORDERS_API_PREFIX = 'ord_';
+
     public function __construct(
         private MollieApiClient $mollieApiClient,
         private General $mollieHelper,
@@ -48,14 +51,26 @@ class CapturePaymentForInvoice
             );
         }
 
-        $capture = $mollieApi->paymentCaptures->createForId($mollieTransactionId, $data);
+        // Orders placed on the module's V2 stored an Orders API id (ord_...). Those payments are linked to an
+        // order and cannot be captured through the Payments API (422 "use the Shipments API instead"). The
+        // Orders API captures them by creating a shipment, so ship all lines to capture the full authorised
+        // amount, matching the pre-V3 behaviour.
+        if (str_starts_with((string) $mollieTransactionId, self::ORDERS_API_PREFIX)) {
+            $shipment = $mollieApi->send(
+                new DynamicPostRequest('orders/' . $mollieTransactionId . '/shipments'),
+            )->toArray();
+            $captureId = $shipment['id'] ?? $mollieTransactionId;
+        } else {
+            $captureId = $mollieApi->paymentCaptures->createForId($mollieTransactionId, $data)->id;
+        }
+
         $payment->setTransactionId($mollieTransactionId);
 
         $order->addCommentToStatusHistory(
             __(
                 'Trying to capture %1. Capture ID: %2',
                 $this->price->format($captureAmount),
-                $capture->id,
+                $captureId,
             ),
             $status,
         );

--- a/Model/Client/Payments/ProcessTransaction.php
+++ b/Model/Client/Payments/ProcessTransaction.php
@@ -15,6 +15,7 @@ use Mollie\Payment\Model\Client\ProcessTransactionResponse;
 use Mollie\Payment\Model\Client\ProcessTransactionResponseFactory;
 use Mollie\Payment\Service\Mollie\MollieApiClient;
 use Mollie\Payment\Service\Mollie\Order\GetTransactionId;
+use Mollie\Payment\Service\Mollie\Order\ResolvePaymentId;
 
 class ProcessTransaction
 {
@@ -23,7 +24,8 @@ class ProcessTransaction
         private PaymentProcessors $paymentProcessors,
         private MollieApiClient $mollieApiClient,
         private MollieHelper $mollieHelper,
-        private GetTransactionId $getTransactionId
+        private GetTransactionId $getTransactionId,
+        private ResolvePaymentId $resolvePaymentId
     ) {}
 
     public function execute(
@@ -32,7 +34,8 @@ class ProcessTransaction
     ): ProcessTransactionResponse {
         $mollieApi = $this->mollieApiClient->loadByStore((int) $magentoOrder->getStoreId());
         $transactionId = $this->getTransactionId->forOrder($magentoOrder);
-        $molliePayment = $mollieApi->payments->get($transactionId);
+        $paymentId = $this->resolvePaymentId->execute($mollieApi, $transactionId);
+        $molliePayment = $mollieApi->payments->get($paymentId);
         $this->mollieHelper->addTolog($type, $molliePayment);
         $status = $molliePayment->status;
 

--- a/Service/Mollie/GetMollieStatus.php
+++ b/Service/Mollie/GetMollieStatus.php
@@ -11,13 +11,15 @@ namespace Mollie\Payment\Service\Mollie;
 
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Mollie\Payment\Service\Mollie\Order\ResolvePaymentId;
 
 class GetMollieStatus
 {
     public function __construct(
         private OrderRepositoryInterface $orderRepository,
         private MollieApiClient $mollieApiClient,
-        private GetMollieStatusResultFactory $getMollieStatusResultFactory
+        private GetMollieStatusResultFactory $getMollieStatusResultFactory,
+        private ResolvePaymentId $resolvePaymentId
     ) {}
 
     public function execute(int $orderId, ?string $transactionId = null): GetMollieStatusResult
@@ -32,7 +34,8 @@ class GetMollieStatus
         }
 
         $mollieApi = $this->mollieApiClient->loadByStore(storeId($order->getStoreId()));
-        $molliePayment = $mollieApi->payments->get($transactionId);
+        $paymentId = $this->resolvePaymentId->execute($mollieApi, $transactionId);
+        $molliePayment = $mollieApi->payments->get($paymentId);
 
         return $this->getMollieStatusResultFactory->create([
             'status' => $molliePayment->status,

--- a/Service/Mollie/Order/ResolvePaymentId.php
+++ b/Service/Mollie/Order/ResolvePaymentId.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Order;
+
+use Magento\Framework\Exception\LocalizedException;
+use Mollie\Api\Http\Requests\DynamicGetRequest;
+use Mollie\Api\MollieApiClient;
+
+/**
+ * Orders placed on the module's V2 stored an Orders API id (ord_...) in mollie_transaction_id. V3 dropped the
+ * Orders API and only talks to the Payments API, so passing such a legacy id to payments->get() returns a 404
+ * and the order can never be processed. This resolves a legacy ord_ id to its underlying payment id (tr_...) so
+ * those orders keep working under V3. Ids that are already payment ids are returned untouched.
+ *
+ * @deprecated This is a transitional fallback for V2 orders only. Remove once no ord_ orders remain in flight.
+ */
+class ResolvePaymentId
+{
+    private const ORDERS_API_PREFIX = 'ord_';
+
+    private const SETTLED_STATUSES = ['paid', 'authorized'];
+
+    public function execute(MollieApiClient $mollieApi, string $transactionId): string
+    {
+        if (!str_starts_with($transactionId, self::ORDERS_API_PREFIX)) {
+            return $transactionId;
+        }
+
+        $payments = $this->fetchEmbeddedPayments($mollieApi, $transactionId);
+
+        return $this->selectPayment($payments, $transactionId)->id;
+    }
+
+    private function fetchEmbeddedPayments(MollieApiClient $mollieApi, string $transactionId): array
+    {
+        $attributes = $mollieApi->send(
+            new DynamicGetRequest('orders/' . $transactionId, ['embed' => 'payments']),
+        )->toArray();
+
+        $embedded = (array) ($attributes['_embedded'] ?? []);
+
+        return $embedded['payments'] ?? [];
+    }
+
+    private function selectPayment(array $payments, string $transactionId): object
+    {
+        foreach ($payments as $payment) {
+            if (in_array($payment->status, self::SETTLED_STATUSES, true)) {
+                return $payment;
+            }
+        }
+
+        $payment = end($payments);
+        if ($payment === false) {
+            throw new LocalizedException(
+                __('No Mollie payment found for legacy order %1', $transactionId),
+            );
+        }
+
+        return $payment;
+    }
+}


### PR DESCRIPTION
Fixes #1027

## Root cause

Orders placed under module v2.x used the Mollie **Orders API** and stored an `ord_` id in `mollie_transaction_id`. After upgrading to v3 (Payments API only), the code sends those legacy `ord_` ids to payment endpoints:

- `payments->get(ord_...)` → **404** on status reads/sync, so the order status never updates.
- `paymentCaptures->createForId(ord_...)` → **404**, then **422** ("use the Shipments API instead") on capture-on-shipment, so the shipment save rolls back and the order never reaches **Complete**.

## What the fix does

- **`Service/Mollie/Order/ResolvePaymentId.php`** (new): resolves a legacy `ord_` id to its underlying payment id (`tr_`) via the Orders API (`embed=payments`). Real `tr_` payment ids are returned untouched, so new orders are unaffected.
- **`Model/Client/Payments/ProcessTransaction.php`** and **`Service/Mollie/GetMollieStatus.php`**: resolve the id with `ResolvePaymentId` before calling `payments->get()`, so status reads/sync work for legacy orders.
- **`Model/Client/Payments/CapturePaymentForInvoice.php`**: for `ord_` ids, capture by creating a ship-all shipment on the Orders API (`orders/{id}/shipments`) instead of a payment capture — matching pre-v3 behaviour and avoiding the 422.

## Test plan

- Legacy `ord_` Klarna Pay later order: capture-on-shipment succeeds, order moves to **Complete**, and the invoice mail is sent.
- New `tr_` orders still capture normally (regression check — `ResolvePaymentId` is a no-op for `tr_` ids).
- Status sync via webhook updates legacy `ord_` orders correctly (no more 404).