### PR TITLE
PIMAG-972 | Bugfix: Include payment_review orders in pending order recovery cron

### DIFF
--- a/Cron/ProcessPendingOrders.php
+++ b/Cron/ProcessPendingOrders.php
@@ -80,7 +80,7 @@ class ProcessPendingOrders
         $batchSize = $this->config->pendingOrderCronBatchSize((int) $store->getId());
 
         $this->searchCriteriaBuilder
-            ->addFilter('state', Order::STATE_PENDING_PAYMENT)
+            ->addFilter('state', [Order::STATE_PENDING_PAYMENT, Order::STATE_PAYMENT_REVIEW], 'in')
             ->addFilter('created_at', $fromDate, 'gt')
             ->addFilter('created_at', $toDate, 'lt')
             ->addFilter('mollie_transaction_id', null, 'notnull')

--- a/Test/Integration/Cron/ProcessPendingOrdersTest.php
+++ b/Test/Integration/Cron/ProcessPendingOrdersTest.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Cron;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Mollie\Payment\Cron\ProcessPendingOrders;
+use Mollie\Payment\Model\Client\ProcessTransactionResponse;
+use Mollie\Payment\Model\Mollie;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class ProcessPendingOrdersTest extends IntegrationTestCase
+{
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/enable_pending_order_cron 1
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRecoversPendingPaymentOrders(): void
+    {
+        $order = $this->prepareOrder(Order::STATE_PENDING_PAYMENT);
+
+        $processedOrderIds = $this->runCron();
+
+        $this->assertContains(
+            (int) $order->getEntityId(),
+            $processedOrderIds,
+            'The cron should pick up orders that are stuck in pending_payment.',
+        );
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/enable_pending_order_cron 1
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRecoversPaymentReviewOrders(): void
+    {
+        $order = $this->prepareOrder(Order::STATE_PAYMENT_REVIEW);
+
+        $processedOrderIds = $this->runCron();
+
+        $this->assertContains(
+            (int) $order->getEntityId(),
+            $processedOrderIds,
+            'Orders stuck in payment_review (manual capture awaiting a capture webhook) must also be recovered.',
+        );
+    }
+
+    private function prepareOrder(string $state): OrderInterface
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->setState($state);
+        $order->setStatus($order->getConfig()->getStateDefaultStatus($state));
+        $order->setMollieTransactionId('tr_dummytransaction');
+        $order->setCreatedAt(gmdate('Y-m-d H:i:s', time() - (2 * 86400)));
+
+        return $this->objectManager->get(OrderRepositoryInterface::class)->save($order);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function runCron(): array
+    {
+        $processedOrderIds = [];
+
+        $mollieFake = new class($processedOrderIds) extends Mollie {
+            public function __construct(private array &$processedOrderIds)
+            {
+            }
+
+            public function processTransaction($orderId, string $type = 'webhook'): ProcessTransactionResponse
+            {
+                $this->processedOrderIds[] = (int) $orderId;
+
+                return new ProcessTransactionResponse(true, 'paid', (string) $orderId, $type);
+            }
+        };
+
+        /** @var ProcessPendingOrders $cron */
+        $cron = $this->objectManager->create(ProcessPendingOrders::class, [
+            'mollieModel' => $mollieFake,
+        ]);
+        $cron->execute();
+
+        return $processedOrderIds;
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...