### PR TITLE
Fixed storeId being a string in Reorder logic

### DIFF
--- a/Service/Order/Reorder.php
+++ b/Service/Order/Reorder.php
@@ -189,7 +189,7 @@ class Reorder
      */
     public function getPaymentMethod(OrderInterface $originalOrder): ?string
     {
-        $value = $this->config->secondChanceUsePaymentMethod($originalOrder->getStoreId());
+        $value = $this->config->secondChanceUsePaymentMethod(storeId($originalOrder->getStoreId()));
 
         if ($value == SecondChancePaymentMethod::USE_PREVIOUS_METHOD) {
             return $originalOrder->getPayment()->getMethod();


### PR DESCRIPTION
the getStoreId() method on the OrderInterface might return a string. We need to ensure it's an int before continuing.

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [x] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [] Contains tests for the changed/added code (great if so but not required).
- [] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [x] Checkout

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When I click on the "Click here to complete your payment" in my second change email, I get the following exception:
```
 Mollie\\Payment\\Config::secondChanceUsePaymentMethod(): Argument #1 ($storeId) must be of type ?int, string given, called in vendor/mollie/magento2/Service/Order/Reorder.php on line 192
```

This is because the storeId is a string in our case. By using the `storeId` helper method, we ensure it's always an integer.

