### PR TITLE
Bugfix: Pass Methods API amount as nested array

### DIFF
--- a/GraphQL/Resolver/General/MolliePaymentMethods.php
+++ b/GraphQL/Resolver/General/MolliePaymentMethods.php
@@ -40,7 +40,7 @@ class MolliePaymentMethods implements ResolverInterface
         }
 
         $storeId = storeId($context->getExtensionAttributes()->getStore()->getId());
-        $apiMethods = $this->getMethods($amount, $currency, $storeId) ?? [];
+        $apiMethods = $this->getMethods($amount, $currency, $storeId);
 
         $methods = [];
         /** @var Method $method */
@@ -66,7 +66,7 @@ class MolliePaymentMethods implements ResolverInterface
         ];
     }
 
-    private function getMethods(float $amount, ?string $currency, int $storeId): ?array
+    private function getMethods(float $amount, ?string $currency, int $storeId): array
     {
         $mollieApiClient = $this->mollieApiClient->loadByStore($storeId);
 
@@ -80,10 +80,12 @@ class MolliePaymentMethods implements ResolverInterface
         }
 
         $parameters = [
-            'amount[value]' => number_format($amount, 2, '.', ''),
-            'amount[currency]' => $currency,
+            'amount' => [
+                'value' => number_format($amount, 2, '.', ''),
+                'currency' => $currency,
+            ],
             'resource' => 'orders',
-            'includeWallets' => 'applepay',
+            'includeWallets' => ['applepay'],
         ];
 
         return (array) $mollieApiClient->methods->allActive(

--- a/Model/MollieConfigProvider.php
+++ b/Model/MollieConfigProvider.php
@@ -76,12 +76,17 @@ class MollieConfigProvider implements ConfigProviderInterface
         try {
             $amount = $this->mollieHelper->getOrderAmountByQuote($cart);
             $parameters = [
-                'amount[value]' => $amount['value'],
-                'amount[currency]' => $amount['currency'],
                 'resource' => 'orders',
                 'includeWallets' => ['applepay'],
                 'billingCountry' => $cart->getBillingAddress()->getCountry(),
             ];
+
+            if ($amount['currency'] !== null) {
+                $parameters['amount'] = [
+                    'value' => $amount['value'],
+                    'currency' => $amount['currency'],
+                ];
+            }
 
             $this->methodData = [];
             $apiMethods = $mollieApi->methods->allEnabled($this->methodParameters->enhance($parameters, $cart));

--- a/Test/Integration/GraphQL/Resolver/General/MolliePaymentMethodsTest.php
+++ b/Test/Integration/GraphQL/Resolver/General/MolliePaymentMethodsTest.php
@@ -11,6 +11,8 @@ namespace Mollie\Payment\Test\Integration\GraphQL\Resolver\General;
 use Exception;
 use Magento\PageCache\Model\Cache\Type;
 use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Data\Money;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\GetEnabledMethodsRequest;
 use Mollie\Api\Http\Requests\GetPaginatedTerminalsRequest;
 use Mollie\Api\MollieApiClient;
@@ -80,6 +82,40 @@ class MolliePaymentMethodsTest extends GraphQLTestCase
         $this->assertCount(2, $result);
         $this->assertEquals('CREDITCARD', $result[0]['name']);
         $this->assertEquals('iDEAL', $result[1]['name']);
+    }
+
+    public function testForwardsTheAmountAndCurrencyToTheMethodsApi(): void
+    {
+        $this->cleanCache();
+        $this->loadFakeEncryptor()->addReturnValue('', 'test_dummyapikeythatisvalidandislongenough');
+
+        $client = MollieApiClient::fake([
+            GetEnabledMethodsRequest::class => MockResponse::ok('method-list'),
+            GetPaginatedTerminalsRequest::class => MockResponse::ok('terminal-list'),
+        ]);
+
+        /** @var FakeMollieApiClient $fakeMollieApiClient */
+        $fakeMollieApiClient = $this->objectManager->get(FakeMollieApiClient::class);
+        $fakeMollieApiClient->setInstance($client);
+        $this->objectManager->addSharedInstance($fakeMollieApiClient, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        $this->graphQlQuery('
+            query {
+                molliePaymentMethods(input: {amount: 34.00, currency: "PLN"}) {
+                    methods {
+                        code
+                    }
+                }
+            }
+        ');
+
+        $client->assertSent(function (PendingRequest $request): bool {
+            $amount = $request->getRequest()->query()->all()['amount'] ?? null;
+
+            return $amount instanceof Money
+                && $amount->currency === 'PLN'
+                && $amount->value === '34.00';
+        });
     }
 
     private function callEndpoint(): array

--- a/Test/Integration/Model/MollieConfigProviderTest.php
+++ b/Test/Integration/Model/MollieConfigProviderTest.php
@@ -8,7 +8,11 @@ declare(strict_types=1);
 
 namespace Mollie\Payment\Test\Integration\Model;
 
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
 use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Data\Money;
+use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\Http\Requests\GetEnabledMethodsRequest;
 use Mollie\Api\MollieApiClient;
 use Mollie\Payment\Config;
@@ -151,6 +155,39 @@ class MollieConfigProviderTest extends IntegrationTestCase
         $this->assertArrayHasKey('locale', $result['payment']['mollie']);
 
         $this->assertSame('nl_NL', $result['payment']['mollie']['locale']);
+    }
+
+    public function testForwardsTheQuoteAmountAndCurrencyToTheMethodsApi(): void
+    {
+        $client = MollieApiClient::fake([
+            GetEnabledMethodsRequest::class => MockResponse::ok('method-list'),
+        ]);
+
+        /** @var FakeMollieApiClient $fakeMollieApiClient */
+        $fakeMollieApiClient = $this->objectManager->get(FakeMollieApiClient::class);
+        $fakeMollieApiClient->setInstance($client);
+        $this->objectManager->addSharedInstance($fakeMollieApiClient, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        /** @var Quote $cart */
+        $cart = $this->objectManager->create(CartInterface::class);
+        $cart->setStoreId(1);
+        $cart->setBaseCurrencyCode('PLN');
+        $cart->setBaseGrandTotal(34.00);
+        $cart->setQuoteCurrencyCode('PLN');
+        $cart->setGrandTotal(34.00);
+        $cart->getBillingAddress()->setCountryId('PL');
+
+        /** @var MollieConfigProvider $instance */
+        $instance = $this->objectManager->create(MollieConfigProvider::class);
+        $instance->getActiveMethods($cart);
+
+        $client->assertSent(function (PendingRequest $request): bool {
+            $amount = $request->getRequest()->query()->all()['amount'] ?? null;
+
+            return $amount instanceof Money
+                && $amount->currency === 'PLN'
+                && $amount->value === '34.00';
+        });
     }
 
     public function testWhenNoActiveMethodsAvailableTheResultIsAnEmptyArray(): void

--- a/Test/Integration/Service/Mollie/MethodParameterPartTest.php
+++ b/Test/Integration/Service/Mollie/MethodParameterPartTest.php
@@ -15,8 +15,10 @@ use Mollie\Payment\Test\Integration\IntegrationTestCase;
 class MethodParameterPartTest extends IntegrationTestCase
 {
     public const DEFAULT_INPUT = [
-        'amount[value]' => 10,
-        'amount[currency]' => 'EUR',
+        'amount' => [
+            'value' => 10,
+            'currency' => 'EUR',
+        ],
         'resource' => 'orders',
         'includeWallets' => ['applepay'],
     ];


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...