### PR TITLE
Update payment reminder onclick action

### DIFF
--- a/Controller/Adminhtml/Action/SendSecondChanceEmail.php
+++ b/Controller/Adminhtml/Action/SendSecondChanceEmail.php
@@ -42,7 +42,7 @@ class SendSecondChanceEmail extends Action implements HttpPostActionInterface
 
         try {
             $reminder = $this->sentPaymentReminderFactory->create();
-            $reminder->setOrderId($order->getEntityId());
+            $reminder->setOrderId((int)$order->getEntityId());
             $this->sentPaymentReminderRepository->save($reminder);
         } catch (CouldNotSaveException) {
             // It might already exist

--- a/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
+++ b/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
@@ -44,7 +44,9 @@ class SecondChanceButton implements ButtonInterface
             'mollie_payment_second_chance_email',
             [
                 'label' => __('Send Payment Reminder'),
-                'onclick' => 'setLocation("' . $this->getUrl((string)$view->getOrderId()) . '")',
+                'onclick' => 'confirmSetLocation(\''
+                    . __('Are you sure you want to send a payment reminder e-mail to the customer?')
+                    . '\', \'' . $this->getUrl((string)$view->getOrderId()) . '\', {data: {}})',
             ],
         );
     }


### PR DESCRIPTION
> Currently, the button sends a `GET` request, while the controller only accepts `POST` requests. This change replaces `setLocation` with `confirmSetLocation`, causing the request to be sent as a `POST`.

---

### **Please describe the bug/feature/etc this PR contains:**

> When attempting to send a **Second Chance** email from the Magento Admin, the **Send payment reminder** button currently issues a `GET` request to `mollie/action/sendSecondChanceEmail`. However, the corresponding controller only accepts `POST` requests, resulting in a **404 Not Found** error.
>
> This PR replaces `setLocation` with `confirmSetLocation`, which submits the request as a `POST`, matching the controller's expected HTTP method and restoring the intended functionality.

---

### **Scenario to test this code:**

> 1. Open an order in the Magento Admin.
> 2. Click the **Send payment reminder** button.
> 3. Confirm the dialog.
> 4. Verify that the request is sent as a `POST` and that the Second Chance email is sent successfully.
