### PR TITLE
Cast scope_id to integer in updateMethodTitle call

### DIFF
--- a/Setup/Patch/Data/RenameIdealToIdealWero.php
+++ b/Setup/Patch/Data/RenameIdealToIdealWero.php
@@ -40,7 +40,7 @@ class RenameIdealToIdealWero implements DataPatchInterface
         foreach ($collection as $configItem) {
             $this->updateMethodTitle(
                 $configItem->getData('scope'),
-                $configItem->getData('scope_id'),
+                (int) $configItem->getData('scope_id'),
                 $configItem->getData('value')
             );
         }


### PR DESCRIPTION
- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [x] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [x] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**

The only change is to the `RenameIdealToIdealWero` setup data patch (writes `core_config_data`).

**Please describe the bug/feature/etc this PR contains:**

When I run `bin/magento setup:upgrade` on a store that has a saved title for the iDEAL payment method, the `RenameIdealToIdealWero` data patch aborts the entire upgrade with a `TypeError`:

```
Mollie\Payment\Setup\Patch\Data\RenameIdealToIdealWero::updateMethodTitle():
Argument #2 ($scopeId) must be of type int, string given,
called in .../mollie/magento2/Setup/Patch/Data/RenameIdealToIdealWero.php on line 41
```

**Root cause:** `apply()` iterates the `core_config_data` rows for `payment/mollie_methods_ideal/title` and passes `$configItem->getData('scope_id')` into `updateMethodTitle(string $scope, int $scopeId, ?string $currentValue = null)`. Values read from the config-data collection are always strings (`"0"`, `"1"`, …), and because the file declares `strict_types=1`, PHP 8 throws a `TypeError` instead of coercing the string to int. This happens for every store that has at least one stored iDEAL title (i.e. the collection is non-empty), so on those stores `setup:upgrade` can never complete.

**Fix:** cast `scope_id` to `int` at the call site. `WriterInterface::save()` already expects an int scope id, so this is the minimal correct change and keeps the existing type contract of `updateMethodTitle()`:

```php
$this->updateMethodTitle(
    $configItem->getData('scope'),
    (int) $configItem->getData('scope_id'),
    $configItem->getData('value')
);
```

**Scenario to test this code:**

Open the environment and:

1. On a Magento 2 store with the Mollie module installed, configure a title for the iDEAL method so a row is written to `core_config_data`: **Stores → Configuration → Sales → Payment Methods → Mollie → iDEAL → Title** (Default or a specific Store View scope), set it to `iDEAL` and save.
2. Make sure the patch is still pending — either a fresh install, or force a re-run:
   `DELETE FROM patch_list WHERE patch_name = 'Mollie\\Payment\\Setup\\Patch\\Data\\RenameIdealToIdealWero';`
3. Run `bin/magento setup:upgrade`.

**Before this PR:** the upgrade aborts with `TypeError: updateMethodTitle(): Argument #2 ($scopeId) must be of type int, string given`.

**After this PR:** `setup:upgrade` completes successfully, and an iDEAL title of `iDEAL` is updated to `iDEAL | Wero` (custom titles are left untouched, as intended).