### PR TITLE
Release/3.1.2

### DIFF
--- a/.github/workflows/templates/magento/configure-mollie.sh
+++ b/.github/workflows/templates/magento/configure-mollie.sh
@@ -58,6 +58,10 @@ bin/magento config:set payment/mollie_methods_wero/active 1
 # Disable queues as we don't have those in the test environment
 bin/magento config:set payment/mollie_general/process_transactions_in_the_queue 0
 
+# Enable Express Components. Not part of the list above because it is not controlled by the Methods API and
+# is hidden in the admin until it is active, so it can only be enabled here.
+bin/magento config:set payment/mollie_methods_expresscomponents/active 1
+
 # Enable Components
 bin/magento config:set payment/mollie_methods_creditcard/use_components 1
 

--- a/Block/Adminhtml/Sales/Order/PartialCaptureNotSupportedNotice.php
+++ b/Block/Adminhtml/Sales/Order/PartialCaptureNotSupportedNotice.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Block\Adminhtml\Sales\Order;
+
+use Magento\Framework\Phrase;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Config;
+use Mollie\Payment\Model\Adminhtml\Source\CaptureMoment;
+use Mollie\Payment\Service\Mollie\Order\CanUseManualCapture;
+use Mollie\Payment\Service\Mollie\Order\SupportsPartialCapture;
+
+class PartialCaptureNotSupportedNotice extends Template
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        Context $context,
+        private readonly Registry $registry,
+        private readonly Config $config,
+        private readonly CanUseManualCapture $canUseManualCapture,
+        private readonly SupportsPartialCapture $supportsPartialCapture,
+        array $data = [],
+    ) {
+        parent::__construct($context, $data);
+    }
+
+    public function toHtml(): string
+    {
+        if (!$this->shouldShowNotice()) {
+            return '';
+        }
+
+        return parent::toHtml();
+    }
+
+    public function getMessage(): Phrase
+    {
+        return __(
+            'Please note: %1 does not support partial captures. Only the complete order can be captured, so a partial invoice or shipment will be refused.',
+            $this->getMethodTitle($this->getOrder()),
+        );
+    }
+
+    private function shouldShowNotice(): bool
+    {
+        $order = $this->getOrder();
+        if ($order === null || $order->getPayment() === null) {
+            return false;
+        }
+
+        if (!$this->canUseManualCapture->execute($order) || $this->supportsPartialCapture->execute($order)) {
+            return false;
+        }
+
+        return $this->capturesOnThisPage($order);
+    }
+
+    private function capturesOnThisPage(OrderInterface $order): bool
+    {
+        $captureMoment = (string) $this->getData('capture_moment');
+        if (!in_array($captureMoment, [CaptureMoment::ON_INVOICE, CaptureMoment::ON_SHIPMENT], true)) {
+            return false;
+        }
+
+        return $this->config->whenToCapture(
+            $order->getPayment()->getMethod(),
+            storeId($order->getStoreId()),
+        ) === $captureMoment;
+    }
+
+    private function getMethodTitle(OrderInterface $order): string
+    {
+        $method = $order->getPayment()->getMethod();
+
+        return $this->config->getMethodTitle($method, storeId($order->getStoreId())) ?: $method;
+    }
+
+    private function getOrder(): ?OrderInterface
+    {
+        return $this->registry->registry((string) $this->getData('registry_key'))?->getOrder();
+    }
+}

--- a/Config.php
+++ b/Config.php
@@ -74,6 +74,7 @@ class Config
     public const PAYMENT_METHOD_WHEN_TO_CAPTURE = 'payment/mollie_methods_%s/when_to_capture';
     public const PAYMENT_METHOD_CAPTURE_DELAY = 'payment/mollie_methods_%s/capture_delay';
     public const PAYMENT_METHOD_CAPTURE_DELAY_UNIT = 'payment/mollie_methods_%s/capture_delay_unit';
+    public const PAYMENT_METHOD_SUPPORTS_PARTIAL_CAPTURE = 'payment/mollie_methods_%s/supports_partial_capture';
     public const PAYMENT_METHOD_PAYMENT_SURCHARGE_FIXED_AMOUNT = 'payment/mollie_methods_%s/payment_surcharge_fixed_amount';
     public const PAYMENT_METHOD_PAYMENT_SURCHARGE_LIMIT = 'payment/mollie_methods_%s/payment_surcharge_limit';
     public const PAYMENT_METHOD_PAYMENT_SURCHARGE_PERCENTAGE = 'payment/mollie_methods_%s/payment_surcharge_percentage';
@@ -111,7 +112,7 @@ class Config
 
     /**
      * @param string $type
-     * @param string|array $data
+     * @param string|array<mixed> $data
      * @return void
      */
     public function addToLog(string $type, $data): void
@@ -189,7 +190,7 @@ class Config
 
     public function getTestApiKey(?int $storeId = null): string
     {
-        $apiKey = trim((string) $this->getPath(static::GENERAL_APIKEY_TEST, $storeId) ?? '');
+        $apiKey = trim((string) $this->getPath(static::GENERAL_APIKEY_TEST, $storeId));
         if (empty($apiKey)) {
             $this->addToLog('error', 'Mollie API key not set (test modus)');
         }
@@ -203,7 +204,7 @@ class Config
 
     public function getLiveApiKey(?int $storeId = null): string
     {
-        $apiKey = trim((string) $this->getPath(static::GENERAL_APIKEY_LIVE, $storeId) ?? '');
+        $apiKey = trim((string) $this->getPath(static::GENERAL_APIKEY_LIVE, $storeId));
         if (empty($apiKey)) {
             $this->addToLog('error', 'Mollie API key not set (live modus)');
         }
@@ -240,6 +241,14 @@ class Config
         return $this->getPath($this->addMethodToPath(static::PAYMENT_METHOD_CAPTURE_DELAY_UNIT, $method), $storeId);
     }
 
+    public function supportsPartialCapture(string $method, ?int $storeId = null): bool
+    {
+        return $this->isSetFlag(
+            $this->addMethodToPath(static::PAYMENT_METHOD_SUPPORTS_PARTIAL_CAPTURE, $method),
+            $storeId,
+        );
+    }
+
     public function isMethodsApiEnabled(?int $storeId = null): bool
     {
         return $this->isSetFlag(static::ADVANCED_ENABLE_METHODS_API, $storeId);
@@ -270,7 +279,7 @@ class Config
         return $this->isSetFlag(static::GENERAL_ENABLE_SECOND_CHANCE_EMAIL, $storeId);
     }
 
-    public function automaticallySendSecondChanceEmails(?int $storeId = null)
+    public function automaticallySendSecondChanceEmails(?int $storeId = null): bool
     {
         if (!$this->isSecondChanceEmailEnabled($storeId)) {
             return false;
@@ -652,11 +661,7 @@ class Config
         return (int) ($this->getPath(static::GENERAL_PENDING_ORDER_CRON_BATCH_SIZE, $storeId) ?? 25);
     }
 
-    /**
-     * @param $method
-     * @return string
-     */
-    private function addMethodToPath($path, $method): string
+    private function addMethodToPath(string $path, ?string $method): string
     {
         return sprintf(
             $path,

--- a/Controller/Adminhtml/Action/SendSecondChanceEmail.php
+++ b/Controller/Adminhtml/Action/SendSecondChanceEmail.php
@@ -42,7 +42,7 @@ class SendSecondChanceEmail extends Action implements HttpPostActionInterface
 
         try {
             $reminder = $this->sentPaymentReminderFactory->create();
-            $reminder->setOrderId($order->getEntityId());
+            $reminder->setOrderId((int)$order->getEntityId());
             $this->sentPaymentReminderRepository->save($reminder);
         } catch (CouldNotSaveException) {
             // It might already exist

--- a/Controller/ApplePay/PlaceOrder.php
+++ b/Controller/ApplePay/PlaceOrder.php
@@ -23,10 +23,12 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\GuestCartRepositoryInterface;
+use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\QuoteManagement;
-use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
 use Mollie\Payment\Config;
 use Mollie\Payment\Service\PaymentToken\Generate;
 use Mollie\Payment\Service\Quote\SetCityFromApplePayAddress;
@@ -52,6 +54,7 @@ class PlaceOrder extends Action implements HttpPostActionInterface
 
     public function execute(): Json
     {
+        /** @var Quote $cart */
         $cart = $this->getCart();
 
         $shippingAddress = $cart->getShippingAddress();
@@ -76,7 +79,7 @@ class PlaceOrder extends Action implements HttpPostActionInterface
             );
         }
 
-        $cart->setPaymentMethod('mollie_methods_applepay');
+        $cart->setData('payment_method', 'mollie_methods_applepay');
         $cart->setCustomerIsGuest(true);
 
         $cart->collectTotals();
@@ -87,7 +90,7 @@ class PlaceOrder extends Action implements HttpPostActionInterface
         $response = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
         try {
-            /** @var OrderInterface $order */
+            /** @var Order $order */
             $order = $this->quoteManagement->submit($cart);
         } catch (Exception $exception) {
             $this->config->addToLog('error', [
@@ -101,7 +104,9 @@ class PlaceOrder extends Action implements HttpPostActionInterface
             return $response->setData(['error' => true, 'message' => $exception->getMessage()]);
         }
 
-        $order->getPayment()->setAdditionalInformation(
+        /** @var Payment $payment */
+        $payment = $order->getPayment();
+        $payment->setAdditionalInformation(
             'applepay_payment_token',
             $this->getRequest()->getParam('applePayPaymentToken'),
         );
@@ -137,7 +142,10 @@ class PlaceOrder extends Action implements HttpPostActionInterface
         return $this->checkoutSession->getQuote();
     }
 
-    private function getAddressLines($addressLines): string
+    /**
+     * @param string[] $addressLines
+     */
+    private function getAddressLines(array $addressLines): string
     {
         $maxLinesCount = $this->scopeConfig->getValue('customer/address/street_lines');
         $linesCount = count($addressLines);
@@ -149,6 +157,9 @@ class PlaceOrder extends Action implements HttpPostActionInterface
         return implode(PHP_EOL, $addressLines);
     }
 
+    /**
+     * @param array<string, mixed> $input
+     */
     private function updateAddress(AddressInterface $address, array $input): void
     {
         $address->addData([

--- a/Controller/ApplePay/PlaceOrder.php
+++ b/Controller/ApplePay/PlaceOrder.php
@@ -29,6 +29,7 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Mollie\Payment\Config;
 use Mollie\Payment\Service\PaymentToken\Generate;
+use Mollie\Payment\Service\Quote\SetCityFromApplePayAddress;
 use Mollie\Payment\Service\Quote\SetRegionFromApplePayAddress;
 
 class PlaceOrder extends Action implements HttpPostActionInterface
@@ -44,6 +45,7 @@ class PlaceOrder extends Action implements HttpPostActionInterface
         private readonly OrderRepositoryInterface $orderRepository,
         private readonly Config $config,
         private readonly ScopeConfigInterface $scopeConfig,
+        private readonly SetCityFromApplePayAddress $setCityFromApplePayAddress,
     ) {
         parent::__construct($context);
     }
@@ -155,10 +157,10 @@ class PlaceOrder extends Action implements HttpPostActionInterface
             // Sometimes the familyName may be empty, fall back to -- in that case.
             AddressInterface::KEY_LASTNAME => $input['familyName'] ?: '--',
             AddressInterface::KEY_FIRSTNAME => $input['givenName'],
-            AddressInterface::KEY_CITY => $input['locality'],
             AddressInterface::KEY_POSTCODE => $input['postalCode'],
         ]);
 
+        $this->setCityFromApplePayAddress->execute($address, $input);
         $this->setRegionFromApplePayAddress->execute($address, $input);
 
         if (isset($input['phoneNumber'])) {

--- a/Controller/Checkout/Redirect.php
+++ b/Controller/Checkout/Redirect.php
@@ -27,6 +27,7 @@ use Mollie\Payment\Config;
 use Mollie\Payment\Model\Mollie;
 use Mollie\Payment\Service\Mollie\FormatExceptionMessages;
 use Mollie\Payment\Service\Mollie\Order\RedirectUrl;
+use Mollie\Payment\Service\Order\OrderAwaitingPaymentFromSession;
 use Mollie\Payment\Service\OrderLockService;
 
 class Redirect extends Action implements HttpGetActionInterface
@@ -42,6 +43,7 @@ class Redirect extends Action implements HttpGetActionInterface
         private readonly RedirectUrl $redirectUrl,
         private readonly FormatExceptionMessages $formatExceptionMessages,
         private readonly OrderLockService $orderLockService,
+        private readonly OrderAwaitingPaymentFromSession $orderAwaitingPaymentFromSession,
     ) {
         parent::__construct($context);
     }
@@ -69,7 +71,7 @@ class Redirect extends Action implements HttpGetActionInterface
             if (!$methodInstance instanceof Mollie) {
                 $msg = __('Payment Method not found');
                 $this->messageManager->addErrorMessage($msg);
-                $this->config->addTolog('error', $msg);
+                $this->config->addTolog('error', (string) $msg);
                 $this->checkoutSession->restoreQuote();
 
                 return $this->_redirect('checkout/cart');
@@ -103,7 +105,7 @@ class Redirect extends Action implements HttpGetActionInterface
                 }
 
                 $order->setState(Order::STATE_PENDING_PAYMENT);
-                $this->orderManagement->cancel($order->getEntityId());
+                $this->orderManagement->cancel((int) $order->getEntityId());
                 $order->addCommentToStatusHistory($order->getEntityId(), $historyMessage);
 
                 $this->config->addToLog('info', sprintf('Canceled order %s', $order->getIncrementId()));
@@ -117,16 +119,18 @@ class Redirect extends Action implements HttpGetActionInterface
     private function getOrder(): OrderInterface
     {
         $token = $this->getRequest()->getParam('paymentToken');
-        if (!$token) {
-            throw new LocalizedException(__('The required payment token is not available'));
+        if (!is_string($token) || $token === '') {
+            return $this->orderAwaitingPaymentFromSession->execute();
         }
 
         $model = $this->paymentTokenRepository->getByToken($token);
         if (!$model) {
-            throw new LocalizedException(__('The payment token %1 does not exists', $token));
+            $this->config->addToLog('error', (string) __('The payment token %1 does not exists', $token));
+
+            return $this->orderAwaitingPaymentFromSession->execute();
         }
 
-        return $this->orderRepository->get($model->getOrderId());
+        return $this->orderRepository->get((int) $model->getOrderId());
     }
 
     private function getMethodInstance(string $method): MethodInterface

--- a/Controller/Express/CreateSession.php
+++ b/Controller/Express/CreateSession.php
@@ -11,12 +11,18 @@ namespace Mollie\Payment\Controller\Express;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 
 class CreateSession implements HttpPostActionInterface
 {
+    public const TYPE_CHECKOUT = 'checkout';
+    public const TYPE_CART = 'cart';
+
+    private const STATUS_SHIPPING_METHOD_REQUIRED = 409;
+
     public function __construct(
         private readonly Session $checkoutSession,
         private readonly JsonFactory $jsonFactory,
@@ -29,10 +35,14 @@ class CreateSession implements HttpPostActionInterface
     public function execute()
     {
         $cart = $this->checkoutSession->getQuote();
+
+        if ($this->isWaitingForShippingMethod($cart)) {
+            return $this->shippingMethodRequiredResponse();
+        }
+
         $this->setEmailOnCart($cart);
 
-        $isExpressCheckout = $this->request->getParam('type') !== 'checkout';
-        $accessToken = $this->createSession->execute($cart, $isExpressCheckout);
+        $accessToken = $this->createSession->execute($cart, $this->isExpressCheckout());
 
         $cart->collectTotals();
         $this->cartRepository->save($cart);
@@ -40,6 +50,41 @@ class CreateSession implements HttpPostActionInterface
         return $this->jsonFactory->create()->setData([
             'clientAccessToken' => $accessToken,
         ]);
+    }
+
+    private function getType(): string
+    {
+        $type = $this->request->getParam('type');
+
+        return is_string($type) ? $type : '';
+    }
+
+    private function isExpressCheckout(): bool
+    {
+        return !in_array($this->getType(), [self::TYPE_CHECKOUT, self::TYPE_CART], true);
+    }
+
+    /*
+     * Without a shipping method the grand total does not include the shipping costs yet, so a session created now
+     * would charge the customer too little. The frontend retries once the shipping method has been selected.
+     */
+    private function isWaitingForShippingMethod(CartInterface $cart): bool
+    {
+        if ($this->getType() !== self::TYPE_CHECKOUT || $cart->getIsVirtual()) {
+            return false;
+        }
+
+        return !$cart->getShippingAddress()->getShippingMethod();
+    }
+
+    private function shippingMethodRequiredResponse(): Json
+    {
+        return $this->jsonFactory->create()
+            ->setHttpResponseCode(self::STATUS_SHIPPING_METHOD_REQUIRED)
+            ->setData([
+                'message' => __('A shipping method must be selected before the payment amount can be determined.')
+                    ->render(),
+            ]);
     }
 
     private function setEmailOnCart(CartInterface $cart): void

--- a/Exceptions/PartialCaptureNotSupported.php
+++ b/Exceptions/PartialCaptureNotSupported.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Exceptions;
+
+use Magento\Framework\Exception\LocalizedException;
+
+class PartialCaptureNotSupported extends LocalizedException
+{
+}

--- a/Model/Client/Payments/CaptureInvoiceForShipment.php
+++ b/Model/Client/Payments/CaptureInvoiceForShipment.php
@@ -12,6 +12,7 @@ use Magento\Sales\Api\Data\InvoiceInterface;
 use Magento\Sales\Api\Data\ShipmentInterface;
 use Magento\Sales\Api\InvoiceRepositoryInterface;
 use Magento\Sales\Model\Service\InvoiceService;
+use Mollie\Payment\Service\Mollie\Order\ValidatePartialCapture;
 
 class CaptureInvoiceForShipment
 {
@@ -19,6 +20,7 @@ class CaptureInvoiceForShipment
         private readonly InvoiceRepositoryInterface $invoiceRepository,
         private readonly InvoiceService $invoiceService,
         private readonly CapturePaymentForInvoice $capturePaymentForInvoice,
+        private readonly ValidatePartialCapture $validatePartialCapture,
     ) {}
 
     public function execute(ShipmentInterface $shipment): ?InvoiceInterface
@@ -30,6 +32,7 @@ class CaptureInvoiceForShipment
         }
 
         $invoice = $this->invoiceService->prepareInvoice($order, $this->getShipmentQtys($shipment));
+        $this->validatePartialCapture->execute($invoice);
         $invoice->register();
 
         $this->invoiceRepository->save($invoice);
@@ -39,6 +42,9 @@ class CaptureInvoiceForShipment
         return $invoice;
     }
 
+    /**
+     * @return array<int, float>
+     */
     private function getShipmentQtys(ShipmentInterface $shipment): array
     {
         $qtys = [];

--- a/Model/Client/Payments/CapturePaymentForInvoice.php
+++ b/Model/Client/Payments/CapturePaymentForInvoice.php
@@ -18,6 +18,7 @@ use Mollie\Payment\Model\OrderLines;
 use Mollie\Payment\Service\Mollie\MollieApiClient;
 use Mollie\Payment\Service\Mollie\Order\CaptureLegacyOrder;
 use Mollie\Payment\Service\Mollie\Order\LegacyOrderTransactionId;
+use Mollie\Payment\Service\Mollie\Order\ValidatePartialCapture;
 
 class CapturePaymentForInvoice
 {
@@ -29,11 +30,14 @@ class CapturePaymentForInvoice
         private CaptureLegacyOrder $captureLegacyOrder,
         private LegacyOrderTransactionId $legacyOrderTransactionId,
         private OrderLines $orderLines,
+        private ValidatePartialCapture $validatePartialCapture,
     ) {
     }
 
     public function execute(InvoiceInterface $invoice): void
     {
+        $this->validatePartialCapture->execute($invoice);
+
         $order = $invoice->getOrder();
         $payment = $order->getPayment();
 

--- a/Model/Cronjob/CleanExpiredOrdersCollection.php
+++ b/Model/Cronjob/CleanExpiredOrdersCollection.php
@@ -8,23 +8,61 @@ declare(strict_types=1);
 
 namespace Mollie\Payment\Model\Cronjob;
 
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactory;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Helper;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot;
 use Magento\Sales\Model\ResourceModel\Order\Collection;
-use Mollie\Payment\Model\Methods\Banktransfer;
+use Mollie\Payment\Service\Mollie\AsyncPaymentMethods;
+use Psr\Log\LoggerInterface;
 
 class CleanExpiredOrdersCollection extends Collection
 {
+    public function __construct(
+        EntityFactory $entityFactory,
+        LoggerInterface $logger,
+        FetchStrategyInterface $fetchStrategy,
+        ManagerInterface $eventManager,
+        Snapshot $entitySnapshot,
+        Helper $coreResourceHelper,
+        private readonly AsyncPaymentMethods $asyncPaymentMethods,
+        ?AdapterInterface $connection = null,
+        ?AbstractDb $resource = null,
+    ) {
+        parent::__construct(
+            $entityFactory,
+            $logger,
+            $fetchStrategy,
+            $eventManager,
+            $entitySnapshot,
+            $coreResourceHelper,
+            $connection,
+            $resource,
+        );
+    }
+
     /**
-     * Do not auto cancel pending banktransfer orders. They may take a few days before they receive an update.
+     * Do not auto cancel pending asynchronous orders. They may take a few days before they receive an update.
+     *
+     * @return string[]
      */
     public function getAllIds($limit = null, $offset = null): array
     {
+        $codes = $this->asyncPaymentMethods->allCodes();
+        if ($codes === []) {
+            return parent::getAllIds($limit, $offset);
+        }
+
         $this->getSelect()
             ->join(
                 ['payment' => $this->getTable('sales_order_payment')],
                 'main_table.entity_id = payment.parent_id',
                 [],
             )
-            ->where('payment.method != ?', Banktransfer::CODE);
+            ->where('payment.method NOT IN (?)', $codes);
 
         return parent::getAllIds($limit, $offset);
     }

--- a/Model/MollieConfigProvider.php
+++ b/Model/MollieConfigProvider.php
@@ -129,6 +129,7 @@ class MollieConfigProvider implements ConfigProviderInterface
         $config['payment']['mollie']['testmode'] = $this->config->isTestMode($storeId);
         $config['payment']['mollie']['profile_id'] = $this->config->getProfileId($storeId);
         $config['payment']['mollie']['locale'] = $this->getLocale($storeId);
+        $config['payment']['mollie']['default_selected_method'] = $this->config->getDefaultSelectedMethod($storeId);
         $config['payment']['mollie']['creditcard']['use_components'] = $this->config->creditcardUseComponents($storeId);
         $config['payment']['mollie']['applepay']['integration_type'] = $this->config->applePayIntegrationType($storeId);
         $config['payment']['mollie']['applepay']['supported_networks'] = $this->supportedNetworks->execute((int)$storeId);

--- a/Model/MollieCustomerRepository.php
+++ b/Model/MollieCustomerRepository.php
@@ -156,7 +156,7 @@ class MollieCustomerRepository implements MollieCustomerRepositoryInterface
     ): bool {
         try {
             $customerModel = $this->mollieCustomerFactory->create();
-            $this->resource->load($customerModel, $customer->getCustomerId());
+            $this->resource->load($customerModel, $customer->getEntityId());
             $this->resource->delete($customerModel);
         } catch (Exception $exception) {
             throw new CouldNotDeleteException(__(

--- a/Model/MollieCustomerRepository.php
+++ b/Model/MollieCustomerRepository.php
@@ -14,7 +14,6 @@ use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
-use Magento\Framework\Api\SearchCriteriaBuilderFactory;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SearchResultsInterface;
 use Magento\Framework\Api\SearchResultsInterfaceFactory;
@@ -22,7 +21,6 @@ use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Reflection\DataObjectProcessor;
-use Magento\Store\Model\StoreManagerInterface;
 use Mollie\Payment\Api\Data\MollieCustomerInterface;
 use Mollie\Payment\Api\Data\MollieCustomerInterfaceFactory;
 use Mollie\Payment\Api\MollieCustomerRepositoryInterface;
@@ -40,11 +38,9 @@ class MollieCustomerRepository implements MollieCustomerRepositoryInterface
         protected SearchResultsInterfaceFactory $searchResultsFactory,
         protected DataObjectHelper $dataObjectHelper,
         protected DataObjectProcessor $dataObjectProcessor,
-        private StoreManagerInterface $storeManager,
         private CollectionProcessorInterface $collectionProcessor,
         protected JoinProcessorInterface $extensionAttributesJoinProcessor,
         protected ExtensibleDataObjectConverter $extensibleDataObjectConverter,
-        private SearchCriteriaBuilderFactory $criteriaBuilderFactory
     ) {}
 
     /**

--- a/Observer/MollieStartTransaction/SavePendingOrder.php
+++ b/Observer/MollieStartTransaction/SavePendingOrder.php
@@ -19,7 +19,7 @@ use Mollie\Payment\Api\Data\PendingPaymentReminderInterfaceFactory;
 use Mollie\Payment\Api\PendingPaymentReminderRepositoryInterface;
 use Mollie\Payment\Config;
 use Mollie\Payment\Helper\General;
-use Mollie\Payment\Model\Methods\Banktransfer;
+use Mollie\Payment\Service\Mollie\AsyncPaymentMethods;
 
 class SavePendingOrder implements ObserverInterface
 {
@@ -28,7 +28,8 @@ class SavePendingOrder implements ObserverInterface
         private Config $config,
         private PendingPaymentReminderInterfaceFactory $reminderFactory,
         private PendingPaymentReminderRepositoryInterface $repository,
-        private EncryptorInterface $encryptor
+        private EncryptorInterface $encryptor,
+        private AsyncPaymentMethods $asyncPaymentMethods,
     ) {}
 
     public function execute(Observer $observer): void
@@ -38,7 +39,7 @@ class SavePendingOrder implements ObserverInterface
 
         if (
             !$this->config->automaticallySendSecondChanceEmails(storeId($order->getStoreId())) ||
-            $order->getPayment()->getMethod() == Banktransfer::CODE
+            $this->asyncPaymentMethods->contains($order->getPayment()?->getMethod())
         ) {
             return;
         }

--- a/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
+++ b/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
@@ -44,7 +44,9 @@ class SecondChanceButton implements ButtonInterface
             'mollie_payment_second_chance_email',
             [
                 'label' => __('Send Payment Reminder'),
-                'onclick' => 'setLocation("' . $this->getUrl((string)$view->getOrderId()) . '")',
+                'onclick' => 'confirmSetLocation(\''
+                    . __('Are you sure you want to send a payment reminder e-mail to the customer?')
+                    . '\', \'' . $this->getUrl((string)$view->getOrderId()) . '\', {data: {}})',
             ],
         );
     }

--- a/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
+++ b/Plugin/Sales/Block/Adminhtml/Order/Buttons/SecondChanceButton.php
@@ -51,7 +51,7 @@ class SecondChanceButton implements ButtonInterface
         );
     }
 
-    private function getUrl(string $orderId)
+    private function getUrl(string $orderId): string
     {
         return $this->url->getUrl('mollie/action/sendSecondChanceEmail/id/' . $orderId);
     }

--- a/Service/Mollie/AsyncPaymentMethods.php
+++ b/Service/Mollie/AsyncPaymentMethods.php
@@ -34,4 +34,15 @@ class AsyncPaymentMethods
     {
         return array_values($this->methods);
     }
+
+    /**
+     * @return string[]
+     */
+    public function allCodes(): array
+    {
+        return array_map(
+            static fn (string $method): string => 'mollie_methods_' . $method,
+            $this->all(),
+        );
+    }
 }

--- a/Service/Mollie/Customer/ForgetMollieCustomerId.php
+++ b/Service/Mollie/Customer/ForgetMollieCustomerId.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Customer;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Api\MollieCustomerRepositoryInterface;
+
+class ForgetMollieCustomerId
+{
+    public function __construct(
+        private CustomerRepositoryInterface $customerRepository,
+        private MollieCustomerRepositoryInterface $mollieCustomerRepository,
+    ) {}
+
+    public function execute(OrderInterface $order): bool
+    {
+        $customerId = $order->getCustomerId();
+        if ($customerId === null) {
+            return false;
+        }
+
+        try {
+            $customer = $this->customerRepository->getById((int)$customerId);
+        } catch (NoSuchEntityException) {
+            return false;
+        }
+
+        $mollieCustomer = $this->mollieCustomerRepository->getByCustomer($customer);
+        if ($mollieCustomer === null) {
+            return false;
+        }
+
+        $this->mollieCustomerRepository->delete($mollieCustomer);
+
+        return true;
+    }
+}

--- a/Service/Mollie/Customer/MollieCustomerNoLongerExists.php
+++ b/Service/Mollie/Customer/MollieCustomerNoLongerExists.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Customer;
+
+use Mollie\Api\Exceptions\ApiException;
+
+class MollieCustomerNoLongerExists
+{
+    private const GONE_STATUS_CODE = 410;
+    private const GONE_RESOURCE = 'customer';
+    private const GONE_DESCRIPTION = 'no longer available';
+
+    public function check(ApiException $exception): bool
+    {
+        if ($exception->getStatusCode() !== self::GONE_STATUS_CODE) {
+            return false;
+        }
+
+        $message = strtolower($exception->getPlainMessage());
+
+        return str_contains($message, self::GONE_RESOURCE) && str_contains($message, self::GONE_DESCRIPTION);
+    }
+}

--- a/Service/Mollie/Order/SupportsPartialCapture.php
+++ b/Service/Mollie/Order/SupportsPartialCapture.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Order;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Config;
+
+class SupportsPartialCapture
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly LegacyOrderTransactionId $legacyOrderTransactionId,
+    ) {}
+
+    public function execute(OrderInterface $order): bool
+    {
+        if ($this->legacyOrderTransactionId->matches((string) $order->getMollieTransactionId())) {
+            return true;
+        }
+
+        return $this->config->supportsPartialCapture(
+            $order->getPayment()->getMethod(),
+            storeId($order->getStoreId()),
+        );
+    }
+}

--- a/Service/Mollie/Order/ValidatePartialCapture.php
+++ b/Service/Mollie/Order/ValidatePartialCapture.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Order;
+
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Config;
+use Mollie\Payment\Exceptions\PartialCaptureNotSupported;
+
+class ValidatePartialCapture
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly PriceCurrencyInterface $priceCurrency,
+        private readonly SupportsPartialCapture $supportsPartialCapture,
+    ) {}
+
+    /**
+     * @throws PartialCaptureNotSupported
+     */
+    public function execute(InvoiceInterface $invoice): void
+    {
+        $order = $invoice->getOrder();
+
+        if ($this->supportsPartialCapture->execute($order)) {
+            return;
+        }
+
+        if ($this->coversTheCompleteOrder($invoice, $order)) {
+            return;
+        }
+
+        throw new PartialCaptureNotSupported(
+            __(
+                '%1 does not support partial captures. Create a single invoice or shipment for the complete order, or cancel the order to release the authorization.',
+                $this->getMethodTitle($order),
+            ),
+        );
+    }
+
+    private function coversTheCompleteOrder(InvoiceInterface $invoice, OrderInterface $order): bool
+    {
+        return $this->priceCurrency->round($invoice->getBaseGrandTotal())
+            === $this->priceCurrency->round($order->getBaseGrandTotal());
+    }
+
+    private function getMethodTitle(OrderInterface $order): string
+    {
+        $method = $order->getPayment()->getMethod();
+
+        return $this->config->getMethodTitle($method, storeId($order->getStoreId())) ?: $method;
+    }
+}

--- a/Service/Mollie/StartTransaction.php
+++ b/Service/Mollie/StartTransaction.php
@@ -11,7 +11,12 @@ namespace Mollie\Payment\Service\Mollie;
 
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Payment;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Payment\Config;
 use Mollie\Payment\Model\Client\Payments as PaymentsApi;
+use Mollie\Payment\Service\Mollie\Customer\ForgetMollieCustomerId;
+use Mollie\Payment\Service\Mollie\Customer\MollieCustomerNoLongerExists;
 use Mollie\Payment\Service\OrderLockService;
 
 class StartTransaction
@@ -22,6 +27,9 @@ class StartTransaction
         private Timeout $timeout,
         private PaymentsApi $paymentsApi,
         private MollieApiClient $mollieApiClient,
+        private MollieCustomerNoLongerExists $mollieCustomerNoLongerExists,
+        private ForgetMollieCustomerId $forgetMollieCustomerId,
+        private Config $config,
     ) {
     }
 
@@ -29,16 +37,45 @@ class StartTransaction
     {
         $this->eventManager->dispatch('mollie_start_transaction', ['order' => $order]);
 
-        return $this->orderLockService->execute($order, function (OrderInterface $order) {
-            $mollieApi = $this->mollieApiClient->loadByStore(storeId($order->getStoreId()));
+        return $this->orderLockService->execute($order, function (OrderInterface $order): ?string {
+            /** @var Payment $payment */
+            $payment = $order->getPayment();
 
             // When clicking the back button from the hosted payment we need a way to verify if the order was paid or not.
             // If this is not the case, we restore the quote. This flag is used to determine if it was paid or not.
-            $order->getPayment()->setAdditionalInformation('mollie_success', false);
+            $payment->setAdditionalInformation('mollie_success', false);
 
-            return $this->timeout->retry(function () use ($order, $mollieApi): ?string {
-                return $this->paymentsApi->startTransaction($order, $mollieApi);
-            });
+            try {
+                return $this->sendTransaction($order);
+            } catch (ApiException $exception) {
+                return $this->retryWithNewMollieCustomer($order, $exception);
+            }
         });
+    }
+
+    private function sendTransaction(OrderInterface $order): ?string
+    {
+        $mollieApi = $this->mollieApiClient->loadByStore(storeId($order->getStoreId()));
+
+        return $this->timeout->retry(fn (): ?string => $this->paymentsApi->startTransaction($order, $mollieApi));
+    }
+
+    private function retryWithNewMollieCustomer(OrderInterface $order, ApiException $exception): ?string
+    {
+        if (!$this->mollieCustomerNoLongerExists->check($exception)) {
+            throw $exception;
+        }
+
+        if (!$this->forgetMollieCustomerId->execute($order)) {
+            throw $exception;
+        }
+
+        $this->config->addToLog('info', sprintf(
+            'The Mollie customer used for order %s no longer exists. ' .
+            'Removed the stored customer and retried the transaction.',
+            $order->getIncrementId(),
+        ));
+
+        return $this->sendTransaction($order);
     }
 }

--- a/Service/Order/OrderAwaitingPaymentFromSession.php
+++ b/Service/Order/OrderAwaitingPaymentFromSession.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Order;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order;
+
+/**
+ * Resolve the order of the checkout session that is still awaiting payment.
+ *
+ * Used as a fallback when no payment token is available, so an order that was placed while the
+ * payment token could not be retrieved is not left behind unpaid.
+ */
+class OrderAwaitingPaymentFromSession
+{
+    public function __construct(
+        private readonly Session $checkoutSession,
+    ) {}
+
+    public function execute(): OrderInterface
+    {
+        $order = $this->checkoutSession->getLastRealOrder();
+        if (!$order->getEntityId()) {
+            throw new LocalizedException(__('There is no order available in the current session'));
+        }
+
+        if ($order->getState() !== Order::STATE_PENDING_PAYMENT) {
+            throw new LocalizedException(
+                __('The order %1 of the current session is not awaiting payment', $order->getIncrementId()),
+            );
+        }
+
+        return $order;
+    }
+}

--- a/Service/Quote/SetCityFromApplePayAddress.php
+++ b/Service/Quote/SetCityFromApplePayAddress.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Quote;
+
+use Magento\Customer\Model\AddressFactory;
+use Magento\Framework\Validator\Factory as ValidatorFactory;
+use Magento\Quote\Api\Data\AddressInterface;
+
+class SetCityFromApplePayAddress
+{
+    private const UNSUPPORTED_CHARACTERS = '/[^\p{L}\p{M}\s\'-]/u';
+    private const CONSECUTIVE_WHITESPACE = '/\s+/u';
+    private const TYPOGRAPHIC_APOSTROPHE = '’';
+    private const VALIDATOR_ENTITY = 'customer_address';
+    private const VALIDATOR_GROUP = 'save';
+
+    public function __construct(
+        private readonly ValidatorFactory $validatorFactory,
+        private readonly AddressFactory $addressFactory,
+    ) {
+    }
+
+    public function execute(AddressInterface $address, array $input): void
+    {
+        $address->setCity($this->getSupportedCity($input['locality'] ?? ''));
+    }
+
+    private function getSupportedCity(string $city): string
+    {
+        if (!$this->isRejectedByMagento($city)) {
+            return $city;
+        }
+
+        $supported = $this->removeUnsupportedCharacters($city);
+
+        if ($supported === '' || $this->isRejectedByMagento($supported)) {
+            return $city;
+        }
+
+        return $supported;
+    }
+
+    private function removeUnsupportedCharacters(string $city): string
+    {
+        return trim(
+            (string)preg_replace(
+                self::CONSECUTIVE_WHITESPACE,
+                ' ',
+                (string)preg_replace(
+                    self::UNSUPPORTED_CHARACTERS,
+                    ' ',
+                    str_replace(self::TYPOGRAPHIC_APOSTROPHE, "'", $city),
+                ),
+            ),
+        );
+    }
+
+    private function isRejectedByMagento(string $city): bool
+    {
+        $address = $this->addressFactory->create();
+        $address->addData([
+            AddressInterface::KEY_FIRSTNAME => 'Apple',
+            AddressInterface::KEY_LASTNAME => 'Pay',
+            AddressInterface::KEY_STREET => ['1'],
+            AddressInterface::KEY_CITY => $city,
+            AddressInterface::KEY_POSTCODE => '1',
+            AddressInterface::KEY_TELEPHONE => '1',
+            AddressInterface::KEY_COUNTRY_ID => 'NL',
+        ]);
+
+        $validator = $this->validatorFactory->createValidator(self::VALIDATOR_ENTITY, self::VALIDATOR_GROUP);
+
+        if ($validator->isValid($address)) {
+            return false;
+        }
+
+        return $this->hasCityMessage($validator->getMessages());
+    }
+
+    private function hasCityMessage(array $messages): bool
+    {
+        if (array_key_exists(AddressInterface::KEY_CITY, $messages)) {
+            return true;
+        }
+
+        return array_filter(
+            $messages,
+            static fn ($message): bool => is_array($message)
+                && array_key_exists(AddressInterface::KEY_CITY, $message),
+        ) !== [];
+    }
+}

--- a/Service/Quote/SetCityFromApplePayAddress.php
+++ b/Service/Quote/SetCityFromApplePayAddress.php
@@ -26,6 +26,9 @@ class SetCityFromApplePayAddress
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $input
+     */
     public function execute(AddressInterface $address, array $input): void
     {
         $address->setCity($this->getSupportedCity($input['locality'] ?? ''));
@@ -83,6 +86,9 @@ class SetCityFromApplePayAddress
         return $this->hasCityMessage($validator->getMessages());
     }
 
+    /**
+     * @param array<string, mixed> $messages
+     */
     private function hasCityMessage(array $messages): bool
     {
         if (array_key_exists(AddressInterface::KEY_CITY, $messages)) {

--- a/Setup/Patch/Data/RenameIdealToIdealWero.php
+++ b/Setup/Patch/Data/RenameIdealToIdealWero.php
@@ -39,8 +39,8 @@ class RenameIdealToIdealWero implements DataPatchInterface
 
         foreach ($collection as $configItem) {
             $this->updateMethodTitle(
-                $configItem->getData('scope'),
-                $configItem->getData('scope_id'),
+                (string)$configItem->getData('scope'),
+                storeId($configItem->getData('scope_id')) ?? 0,
                 $configItem->getData('value')
             );
         }
@@ -48,8 +48,12 @@ class RenameIdealToIdealWero implements DataPatchInterface
         return $this;
     }
 
-    private function updateMethodTitle(string $scope, int $scopeId, ?string $currentValue = null)
+    private function updateMethodTitle(string $scope, int $scopeId, ?string $currentValue = null): void
     {
+        if ($currentValue === null) {
+            return;
+        }
+
         // Some merchant might have iDEAL + €1 or something similar, don't update those
         if (strtolower($currentValue) !== 'ideal') {
             return;

--- a/Test/End-2-end/tests/express-components.spec.ts
+++ b/Test/End-2-end/tests/express-components.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import {expect, Page, test} from '@playwright/test';
+import ProductPage from "Pages/frontend/ProductPage";
+import CheckoutPage from "Pages/frontend/CheckoutPage";
+import CheckoutShippingPage from "Pages/frontend/CheckoutShippingPage";
+import FrontendLogin from "Pages/frontend/FrontendLogin";
+import VisitCheckoutPaymentCompositeAction from "CompositeActions/VisitCheckoutPaymentCompositeAction";
+
+const productPage = new ProductPage();
+const checkoutPage = new CheckoutPage();
+const checkoutShippingPage = new CheckoutShippingPage();
+const frontendLogin = new FrontendLogin();
+const visitCheckoutPayment = new VisitCheckoutPaymentCompositeAction();
+
+const CREATE_SESSION_PATH = '/mollie/express/createSession';
+
+function recordCreateSessionRequests(page: Page): string[] {
+  const urls: string[] = [];
+
+  page.on('request', (request) => {
+    if (request.url().includes(CREATE_SESSION_PATH)) {
+      urls.push(request.url());
+    }
+  });
+
+  return urls;
+}
+
+test('[1186] The express session is not created before a shipping method is selected', async ({ page }) => {
+  const requests = recordCreateSessionRequests(page);
+
+  await productPage.openProduct(page, 4);
+  await productPage.addSimpleProductToCart(page);
+
+  await checkoutPage.visit(page);
+
+  // Filling the address sets the guest email and reloads the totals. Before the fix the session was created
+  // here, while the grand total still excluded the shipping costs.
+  await visitCheckoutPayment.fillAddress(page, 'NL');
+
+  expect(
+    requests,
+    'no express session may be created while the grand total still excludes the shipping costs'
+  ).toHaveLength(0);
+
+  await checkoutShippingPage.selectFirstAvailableShippingMethod(page);
+  await checkoutPage.continue(page);
+
+  await expect
+    .poll(() => requests.length, {
+      message: 'the express session must be created once the shipping method is known',
+    })
+    .toBeGreaterThan(0);
+
+  for (const url of requests) {
+    expect(url).toContain(`${CREATE_SESSION_PATH}/type/checkout`);
+  }
+});
+
+test('[1186] The cart page creates its express session with the cart type', async ({ page }) => {
+  const requests = recordCreateSessionRequests(page);
+
+  // The cart placement only creates a session for logged in customers, because a guest has no email on the
+  // quote at that point. That is unchanged behaviour, but it means this test cannot run as a guest.
+  await frontendLogin.register(page, `express-components-${Date.now()}@mollie.com`, 'Mollie123!');
+
+  await productPage.openProduct(page, 4);
+  await productPage.addSimpleProductToCart(page);
+
+  await page.goto('/checkout/cart');
+
+  await expect
+    .poll(() => requests.length, {
+      message: 'the cart page must create an express session',
+    })
+    .toBeGreaterThan(0);
+
+  for (const url of requests) {
+    expect(
+      url,
+      'the cart page has no shipping method yet, so it must not use the checkout type'
+    ).toContain(`${CREATE_SESSION_PATH}/type/cart`);
+  }
+});

--- a/Test/End-2-end/tests/failed-payment-token.spec.ts
+++ b/Test/End-2-end/tests/failed-payment-token.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import {expect, test} from '@playwright/test';
+import CheckoutPaymentPage from "Pages/frontend/CheckoutPaymentPage";
+import VisitCheckoutPaymentCompositeAction from "CompositeActions/VisitCheckoutPaymentCompositeAction";
+
+const checkoutPaymentPage = new CheckoutPaymentPage();
+const visitCheckoutPayment = new VisitCheckoutPaymentCompositeAction();
+
+const placeOrderButton = '.payment-method._active .action.primary.checkout';
+
+const isPlaceOrderRequest = (request) =>
+  request.method() === 'POST' && new URL(request.url()).pathname.endsWith('/payment-information');
+
+// https://github.com/magmodules/mollie-magento2/issues/1182
+// placeOrder() chains the payment token request with .always(), so the Magento order is placed
+// even when GET .../mollie/payment-token fails. The token observable is only filled in .done(),
+// so afterPlaceOrder() then sends the shopper to mollie/checkout/redirect/paymentToken/undefined.
+// The order is left in pending_payment without a Mollie payment ever being created.
+test('[1182] A failing payment token request does not place an order', async ({ page }) => {
+  await visitCheckoutPayment.visit(page);
+
+  // The request carries a jQuery cache buster (?_=<timestamp>), so match on the path with a regex.
+  await page.route(/\/mollie\/payment-token/, (route) => route.abort('failed'));
+
+  const placeOrderRequest = page
+    .waitForRequest(isPlaceOrderRequest, { timeout: 15000 })
+    .catch(() => null);
+
+  await checkoutPaymentPage.selectPaymentMethod(page, 'iDEAL | Wero');
+  await checkoutPaymentPage.placeOrder(page);
+
+  expect(await placeOrderRequest).toBeNull();
+
+  expect(page.url()).not.toContain('paymentToken');
+  expect(page.url()).toContain('/checkout');
+
+  await expect(page.locator(placeOrderButton)).toBeEnabled();
+  await expect(page.locator('.payment-method._active .message-error'))
+    .toContainText('We were unable to start your payment');
+});

--- a/Test/Integration/Block/Adminhtml/Sales/Order/PartialCaptureNotSupportedNoticeTest.php
+++ b/Test/Integration/Block/Adminhtml/Sales/Order/PartialCaptureNotSupportedNoticeTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Block\Adminhtml\Sales\Order;
+
+use Magento\Framework\Registry;
+use Magento\Framework\View\LayoutInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Shipment;
+use Mollie\Payment\Block\Adminhtml\Sales\Order\PartialCaptureNotSupportedNotice;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @magentoAppArea adminhtml
+ */
+class PartialCaptureNotSupportedNoticeTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/capture_mode manual
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/when_to_capture shipment
+     */
+    public function testShowsTheNoticeForAMethodWithoutPartialCaptures(): void
+    {
+        $html = $this->render('mollie_methods_riverty');
+
+        $this->assertStringContainsString('Riverty does not support partial captures', $html);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_creditcard/capture_mode manual
+     * @magentoConfigFixture default_store payment/mollie_methods_creditcard/when_to_capture shipment
+     */
+    public function testHidesTheNoticeForAMethodWithPartialCaptures(): void
+    {
+        $this->assertSame('', $this->render('mollie_methods_creditcard'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/capture_mode automatic
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/when_to_capture shipment
+     */
+    public function testHidesTheNoticeWhenTheOrderIsCapturedAutomatically(): void
+    {
+        $this->assertSame('', $this->render('mollie_methods_riverty'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/capture_mode manual
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/when_to_capture invoice
+     */
+    public function testHidesTheNoticeOnThePageThatDoesNotTriggerTheCapture(): void
+    {
+        $this->assertSame('', $this->render('mollie_methods_riverty'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/capture_mode manual
+     */
+    public function testHidesTheNoticeWhenNoCaptureMomentIsConfigured(): void
+    {
+        $this->assertSame('', $this->render('mollie_methods_riverty'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testHidesTheNoticeForANonMollieOrder(): void
+    {
+        $this->assertSame('', $this->render('checkmo'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testHidesTheNoticeWhenNothingIsRegistered(): void
+    {
+        $block = $this->objectManager->create(PartialCaptureNotSupportedNotice::class);
+        $block->setData('registry_key', 'current_shipment');
+        $block->setData('capture_moment', 'shipment');
+
+        $this->assertSame('', $block->toHtml());
+    }
+
+    /**
+     * @dataProvider layoutHandlesProvider
+     */
+    #[DataProvider('layoutHandlesProvider')]
+    public function testIsAddedToTheLayoutHandleWithTheMatchingArguments(
+        string $handle,
+        string $registryKey,
+        string $captureMoment,
+    ): void {
+        $layout = $this->objectManager->create(LayoutInterface::class);
+        $layout->getUpdate()->load($handle);
+
+        $blocks = $layout->getUpdate()->asSimplexml()
+            ->xpath('//block[@name="mollie.partial.capture.not.supported"]');
+
+        $this->assertNotEmpty($blocks, sprintf('The notice is not added to the "%s" layout handle', $handle));
+
+        $arguments = $this->argumentsOf($blocks[0]);
+
+        $this->assertSame($registryKey, $arguments['registry_key'] ?? null);
+        $this->assertSame($captureMoment, $arguments['capture_moment'] ?? null);
+    }
+
+    public static function layoutHandlesProvider(): array
+    {
+        return [
+            ['sales_order_invoice_new', 'current_invoice', 'invoice'],
+            ['sales_order_invoice_updateqty', 'current_invoice', 'invoice'],
+            ['adminhtml_order_shipment_new', 'current_shipment', 'shipment'],
+        ];
+    }
+
+    private function argumentsOf(\SimpleXMLElement $block): array
+    {
+        $arguments = [];
+        foreach ($block->xpath('arguments/argument') as $argument) {
+            $arguments[(string) $argument->attributes()->name] = (string) $argument;
+        }
+
+        return $arguments;
+    }
+
+    private function render(string $method): string
+    {
+        /** @var Order $order */
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+        $order->setMollieTransactionId('tr_dummytransaction');
+
+        /** @var Shipment $shipment */
+        $shipment = $this->objectManager->create(Shipment::class);
+        $shipment->setOrder($order);
+
+        $this->objectManager->get(Registry::class)->unregister('current_shipment');
+        $this->objectManager->get(Registry::class)->register('current_shipment', $shipment);
+
+        $block = $this->objectManager->create(PartialCaptureNotSupportedNotice::class);
+        $block->setData('registry_key', 'current_shipment');
+        $block->setData('capture_moment', 'shipment');
+        $block->setTemplate('Mollie_Payment::order/partial_capture_not_supported.phtml');
+
+        return $block->toHtml();
+    }
+}

--- a/Test/Integration/Controller/ApplePay/PlaceOrderTest.php
+++ b/Test/Integration/Controller/ApplePay/PlaceOrderTest.php
@@ -1,0 +1,189 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Controller\ApplePay;
+
+use Magento\Checkout\Model\Session;
+use Magento\Customer\Model\Address;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\Validator\Factory as ValidatorFactory;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order;
+use Magento\TestFramework\TestCase\AbstractController;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class PlaceOrderTest extends AbstractController
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/quote.php
+     * @magentoConfigFixture current_store carriers/flatrate/active 1
+     * @magentoConfigFixture current_store payment/mollie_general/enabled 1
+     * @magentoConfigFixture current_store payment/mollie_general/type test
+     * @magentoConfigFixture current_store payment/mollie_general/apikey_test test_dummydummydummydummydummydummy
+     * @magentoConfigFixture current_store payment/mollie_general/enable_second_chance_email 0
+     * @magentoConfigFixture current_store payment/mollie_methods_applepay/active 1
+     * @dataProvider localityProvider
+     */
+    #[DataProvider('localityProvider')]
+    public function testPlacesTheOrderWithACityTheMagentoValidatorAccepts(string $locality): void
+    {
+        $this->prepareGuestQuote();
+
+        $this->dispatchPlaceOrder($locality);
+
+        $response = json_decode($this->getResponse()->getBody(), true);
+        $this->assertSame(
+            200,
+            $this->getResponse()->getHttpResponseCode(),
+            'Placing the Apple Pay order failed for the locality "' . $locality . '": ' . ($response['message'] ?? ''),
+        );
+        $this->assertFalse($response['error']);
+
+        $city = $this->getPlacedOrder()->getBillingAddress()->getCity();
+        $this->assertTrue(
+            $this->isAcceptedByMagento($city),
+            'The city "' . $city . '" is rejected by the Magento address validator',
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/quote.php
+     * @magentoConfigFixture current_store carriers/flatrate/active 1
+     * @magentoConfigFixture current_store payment/mollie_general/enabled 1
+     * @magentoConfigFixture current_store payment/mollie_general/type test
+     * @magentoConfigFixture current_store payment/mollie_general/apikey_test test_dummydummydummydummydummydummy
+     * @magentoConfigFixture current_store payment/mollie_general/enable_second_chance_email 0
+     * @magentoConfigFixture current_store payment/mollie_methods_applepay/active 1
+     * @dataProvider localityProvider
+     */
+    #[DataProvider('localityProvider')]
+    public function testKeepsTheLocalityUnchangedWhenTheMagentoValidatorAcceptsIt(string $locality): void
+    {
+        if (!$this->isAcceptedByMagento($locality)) {
+            $this->markTestSkipped('The Magento address validator of this version rejects "' . $locality . '"');
+        }
+
+        $this->prepareGuestQuote();
+
+        $this->dispatchPlaceOrder($locality);
+
+        $this->assertSame($locality, $this->getPlacedOrder()->getBillingAddress()->getCity());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/quote.php
+     * @magentoConfigFixture current_store carriers/flatrate/active 1
+     * @magentoConfigFixture current_store payment/mollie_general/enabled 1
+     * @magentoConfigFixture current_store payment/mollie_general/type test
+     * @magentoConfigFixture current_store payment/mollie_general/apikey_test test_dummydummydummydummydummydummy
+     * @magentoConfigFixture current_store payment/mollie_general/enable_second_chance_email 0
+     * @magentoConfigFixture current_store payment/mollie_methods_applepay/active 1
+     * @dataProvider supportedCityProvider
+     */
+    #[DataProvider('supportedCityProvider')]
+    public function testFallsBackToASupportedCityWhenTheMagentoValidatorRejectsTheLocality(
+        string $locality,
+        string $supportedCity,
+    ): void {
+        if ($this->isAcceptedByMagento($locality)) {
+            $this->markTestSkipped('The Magento address validator of this version accepts "' . $locality . '"');
+        }
+
+        $this->prepareGuestQuote();
+
+        $this->dispatchPlaceOrder($locality);
+
+        $this->assertSame($supportedCity, $this->getPlacedOrder()->getBillingAddress()->getCity());
+    }
+
+    public static function localityProvider(): array
+    {
+        return array_map(
+            static fn (array $case): array => [$case[0]],
+            self::supportedCityProvider(),
+        );
+    }
+
+    public static function supportedCityProvider(): array
+    {
+        return [
+            'period' => ['St. Albans', 'St Albans'],
+            'digits' => ['Rome 00184', 'Rome'],
+            'parentheses' => ['Saint-Denis (93)', 'Saint-Denis'],
+            'slash' => ['Newcastle / Tyne', 'Newcastle Tyne'],
+            'typographic apostrophe' => ['O’Fallon', "O'Fallon"],
+        ];
+    }
+
+    private function prepareGuestQuote(): void
+    {
+        /** @var Quote $quote */
+        $quote = $this->_objectManager->create(Quote::class);
+        $quote->load('test01', 'reserved_order_id');
+        $quote->setIsMultiShipping(false);
+        $quote->setIsActive(true);
+        $quote->getShippingAddress()->setCollectShippingRates(true);
+
+        $this->_objectManager->get(CartRepositoryInterface::class)->save($quote);
+        $this->_objectManager->get(Session::class)->setQuoteId($quote->getId());
+    }
+
+    private function dispatchPlaceOrder(string $locality): void
+    {
+        $contact = [
+            'addressLines' => ['Sample Street 1'],
+            'countryCode' => 'GB',
+            'givenName' => 'Sample',
+            'familyName' => 'Shopper',
+            'locality' => $locality,
+            'postalCode' => 'AL1 1AA',
+            'phoneNumber' => '0123456789',
+            'emailAddress' => 'sample.shopper@example.com',
+        ];
+
+        $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
+        $this->getRequest()->setPostValue([
+            'shippingAddress' => $contact,
+            'billingAddress' => $contact,
+            'shippingMethod' => ['identifier' => 'flatrate__SPLIT__flatrate'],
+            'applePayPaymentToken' => '{"paymentData":"sample"}',
+        ]);
+
+        $this->dispatch('mollie/applePay/placeOrder');
+    }
+
+    private function getPlacedOrder(): OrderInterface
+    {
+        /** @var Order $order */
+        $order = $this->_objectManager->create(Order::class);
+        $order->loadByIncrementId('test01');
+
+        $this->assertNotNull($order->getId(), 'No order was created for the Apple Pay request');
+
+        return $order;
+    }
+
+    private function isAcceptedByMagento(string $city): bool
+    {
+        /** @var Address $address */
+        $address = $this->_objectManager->create(Address::class);
+        $address->setFirstname('Sample')
+            ->setLastname('Shopper')
+            ->setStreet(['Sample Street 1'])
+            ->setCity($city)
+            ->setPostcode('AL1 1AA')
+            ->setTelephone('0123456789')
+            ->setCountryId('GB');
+
+        return $this->_objectManager->get(ValidatorFactory::class)
+            ->createValidator('customer_address', 'save')
+            ->isValid($address);
+    }
+}

--- a/Test/Integration/Controller/Checkout/RedirectTest.php
+++ b/Test/Integration/Controller/Checkout/RedirectTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Controller\Checkout;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
+use Magento\TestFramework\TestCase\AbstractController;
+use Mollie\Payment\Model\Methods\Ideal;
+use Mollie\Payment\Service\Mollie\Order\RedirectUrl;
+use Mollie\Payment\Service\PaymentToken\Generate;
+
+class RedirectTest extends AbstractController
+{
+    private const MOLLIE_REDIRECT_URL = 'https://www.mollie.com/checkout/test-redirect';
+
+    public function testRedirectsToCartWhenThereIsNoTokenAndNoOrderInTheSession(): void
+    {
+        $this->dispatch('mollie/checkout/redirect');
+
+        $this->assertRedirect($this->stringContains('checkout/cart'));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testUsesTheOrderOfTheSessionWhenTheTokenIsMissing(): void
+    {
+        $order = $this->createMollieOrderAwaitingPayment();
+        $this->addOrderToSession($order);
+        $this->assertRedirectUrlIsBuiltForOrder($order);
+
+        $this->dispatch('mollie/checkout/redirect');
+
+        $this->assertRedirect($this->stringContains(static::MOLLIE_REDIRECT_URL));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testUsesTheOrderOfTheSessionWhenTheTokenIsUnknown(): void
+    {
+        $order = $this->createMollieOrderAwaitingPayment();
+        $this->addOrderToSession($order);
+        $this->assertRedirectUrlIsBuiltForOrder($order);
+
+        $this->dispatch('mollie/checkout/redirect/paymentToken/undefined');
+
+        $this->assertRedirect($this->stringContains(static::MOLLIE_REDIRECT_URL));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/quote.php
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testUsesTheOrderOfTheTokenWhenOneIsProvided(): void
+    {
+        $order = $this->createMollieOrderAwaitingPayment();
+        $order->setQuoteId($this->loadQuoteOfFixture()->getId());
+
+        $token = $this->_objectManager->create(Generate::class)->forOrder($order);
+        $this->assertRedirectUrlIsBuiltForOrder($order);
+
+        $this->dispatch('mollie/checkout/redirect/paymentToken/' . $token->getToken());
+
+        $this->assertRedirect($this->stringContains(static::MOLLIE_REDIRECT_URL));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRedirectsToCartWhenTheOrderOfTheSessionIsNotAwaitingPayment(): void
+    {
+        $order = $this->createMollieOrderAwaitingPayment();
+        $order->setState(Order::STATE_PROCESSING);
+        $this->_objectManager->get(OrderRepositoryInterface::class)->save($order);
+
+        $this->addOrderToSession($order);
+
+        $redirectUrl = $this->createMock(RedirectUrl::class);
+        $redirectUrl->expects($this->never())->method('execute');
+        $this->_objectManager->addSharedInstance($redirectUrl, RedirectUrl::class);
+
+        $this->dispatch('mollie/checkout/redirect');
+
+        $this->assertRedirect($this->stringContains('checkout/cart'));
+    }
+
+    private function createMollieOrderAwaitingPayment(): OrderInterface
+    {
+        $repository = $this->_objectManager->get(OrderRepositoryInterface::class);
+        $builder = $this->_objectManager->create(SearchCriteriaBuilder::class);
+        $searchCriteria = $builder->addFilter('increment_id', '100000001', 'eq')->create();
+
+        $orders = $repository->getList($searchCriteria)->getItems();
+        $order = array_shift($orders);
+
+        $order->getPayment()->setMethod(Ideal::CODE);
+        $order->setState(Order::STATE_PENDING_PAYMENT);
+
+        return $repository->save($order);
+    }
+
+    private function loadQuoteOfFixture(): Quote
+    {
+        $quote = $this->_objectManager->create(Quote::class);
+        $quote->load('test01', 'reserved_order_id');
+
+        return $quote;
+    }
+
+    private function addOrderToSession(OrderInterface $order): void
+    {
+        $this->_objectManager->get(Session::class)->setLastRealOrderId($order->getIncrementId());
+    }
+
+    private function assertRedirectUrlIsBuiltForOrder(OrderInterface $order): void
+    {
+        $redirectUrl = $this->createMock(RedirectUrl::class);
+        $redirectUrl->expects($this->once())
+            ->method('execute')
+            ->with($this->anything(), $this->callback(
+                fn (OrderInterface $subject) => $subject->getEntityId() === $order->getEntityId(),
+            ))
+            ->willReturn(static::MOLLIE_REDIRECT_URL);
+
+        $this->_objectManager->addSharedInstance($redirectUrl, RedirectUrl::class);
+    }
+}

--- a/Test/Integration/Controller/Express/CreateSessionTest.php
+++ b/Test/Integration/Controller/Express/CreateSessionTest.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Controller\Express;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Request\Http;
+use Magento\TestFramework\Quote\Model\GetQuoteByReservedOrderId;
+use Magento\TestFramework\TestCase\AbstractController;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\MollieApiClient;
+use Mollie\Payment\Service\Mollie\Api\CreateSessionRequest;
+use Mollie\Payment\Test\Fakes\Service\Mollie\FakeMollieApiClient;
+
+class CreateSessionTest extends AbstractController
+{
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     */
+    public function testDoesNotCreateACheckoutSessionWhenNoShippingMethodIsSelected(): void
+    {
+        $client = $this->fakeSessionRequest();
+        $this->activateQuoteOnCheckoutSession();
+
+        $this->dispatchCreateSession('mollie/express/createSession/type/checkout');
+
+        $this->assertEquals(409, $this->getResponse()->getHttpResponseCode());
+        $client->assertSentCount(0);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address_and_shipping_method_saved.php
+     */
+    public function testCreatesACheckoutSessionWhenAShippingMethodIsSelected(): void
+    {
+        $client = $this->fakeSessionRequest();
+        $this->activateQuoteOnCheckoutSession();
+
+        $this->dispatchCreateSession('mollie/express/createSession/type/checkout');
+
+        $this->assertEquals(200, $this->getResponse()->getHttpResponseCode());
+        $client->assertSentCount(1);
+    }
+
+    /**
+     * The cart page has no shipping method yet, so it must not be blocked by the checkout requirement.
+     *
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address_saved.php
+     */
+    public function testCreatesACartSessionWithoutAShippingMethod(): void
+    {
+        $client = $this->fakeSessionRequest();
+        $this->activateQuoteOnCheckoutSession();
+
+        $this->dispatchCreateSession('mollie/express/createSession/type/cart');
+
+        $this->assertEquals(200, $this->getResponse()->getHttpResponseCode());
+        $client->assertSentCount(1);
+    }
+
+    private function dispatchCreateSession(string $path): void
+    {
+        $this->getRequest()->setMethod(Http::METHOD_POST);
+
+        $this->dispatch($path);
+    }
+
+    private function activateQuoteOnCheckoutSession(): void
+    {
+        $quote = $this->_objectManager->get(GetQuoteByReservedOrderId::class)->execute('test_order_1');
+
+        $checkoutSession = $this->createStub(Session::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
+
+        $this->_objectManager->addSharedInstance($checkoutSession, Session::class);
+    }
+
+    private function fakeSessionRequest(): MollieApiClient
+    {
+        $client = MollieApiClient::fake([
+            CreateSessionRequest::class => MockResponse::ok('session'),
+        ], true);
+
+        /** @var FakeMollieApiClient $fake */
+        $fake = $this->_objectManager->create(FakeMollieApiClient::class);
+        $fake->setInstance($client);
+        $this->_objectManager->addSharedInstance($fake, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        return $client;
+    }
+}

--- a/Test/Integration/Model/Client/Payments/CaptureInvoiceForShipmentTest.php
+++ b/Test/Integration/Model/Client/Payments/CaptureInvoiceForShipmentTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Model\Client\Payments;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Sales\Api\Data\ShipmentInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Sales\Model\Order\ShipmentFactory;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\CreatePaymentCaptureRequest;
+use Mollie\Payment\Exceptions\PartialCaptureNotSupported;
+use Mollie\Payment\Model\Client\Payments\CaptureInvoiceForShipment;
+use Mollie\Payment\Test\Fakes\Service\Mollie\FakeMollieApiClient;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class CaptureInvoiceForShipmentTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRefusesAPartialShipmentWhenTheMethodDoesNotSupportPartialCaptures(): void
+    {
+        $this->fakeCaptureApi();
+
+        $order = $this->prepareOrder('mollie_methods_riverty');
+        $instance = $this->objectManager->create(CaptureInvoiceForShipment::class);
+
+        $this->expectException(PartialCaptureNotSupported::class);
+        $instance->execute($this->shipmentFor($order, 1));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCreatesNoInvoiceAndCallsNoApiForARefusedPartialShipment(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $order = $this->prepareOrder('mollie_methods_riverty');
+        $instance = $this->objectManager->create(CaptureInvoiceForShipment::class);
+
+        try {
+            $instance->execute($this->shipmentFor($order, 1));
+            $this->fail('Expected the partial shipment to be refused');
+        } catch (PartialCaptureNotSupported $exception) {
+            $this->assertSame(0, $this->countStoredInvoices($order));
+            $fake->loadByStore()->assertSentCount(0);
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCapturesAShipmentThatCoversTheCompleteOrder(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $order = $this->prepareOrder('mollie_methods_riverty');
+        $instance = $this->objectManager->create(CaptureInvoiceForShipment::class);
+
+        $invoice = $instance->execute($this->shipmentFor($order, 2));
+
+        $this->assertNotNull($invoice);
+        $fake->loadByStore()->assertSent(CreatePaymentCaptureRequest::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCapturesAPartialShipmentWhenTheMethodSupportsPartialCaptures(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $order = $this->prepareOrder('mollie_methods_creditcard');
+        $instance = $this->objectManager->create(CaptureInvoiceForShipment::class);
+
+        $invoice = $instance->execute($this->shipmentFor($order, 1));
+
+        $this->assertNotNull($invoice);
+        $fake->loadByStore()->assertSent(CreatePaymentCaptureRequest::class);
+    }
+
+    private function fakeCaptureApi(): FakeMollieApiClient
+    {
+        $fake = $this->loadFakeMollieApiClient();
+        $fake->fake([
+            CreatePaymentCaptureRequest::class => MockResponse::created(
+                '{"resource":"capture","id":"cpt_dummycapture","paymentId":"tr_dummytransaction","status":"pending"}',
+            ),
+        ], true);
+
+        return $fake;
+    }
+
+    private function prepareOrder(string $method): Order
+    {
+        /** @var Order $order */
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+        $order->setMollieTransactionId('tr_dummytransaction');
+
+        $total = $this->totalOfAllItems($order);
+        $order->setBaseSubtotal($total);
+        $order->setSubtotal($total);
+        $order->setBaseGrandTotal($total);
+        $order->setGrandTotal($total);
+
+        return $order;
+    }
+
+    private function totalOfAllItems(Order $order): float
+    {
+        return array_reduce(
+            $order->getAllItems(),
+            function (float $total, OrderItem $item): float {
+                $rowTotal = (float) $item->getBasePrice() * (float) $item->getQtyOrdered();
+                $item->setBaseRowTotal($rowTotal);
+                $item->setRowTotal($rowTotal);
+
+                return $total + $rowTotal;
+            },
+            0.0,
+        );
+    }
+
+    private function shipmentFor(Order $order, float $qty): ShipmentInterface
+    {
+        $items = array_reduce(
+            $order->getAllItems(),
+            fn (array $items, $item): array => $items + [(int) $item->getId() => $qty],
+            [],
+        );
+
+        return $this->objectManager->create(ShipmentFactory::class)->create($order, $items);
+    }
+
+    private function countStoredInvoices(Order $order): int
+    {
+        $searchCriteria = $this->objectManager->create(SearchCriteriaBuilder::class)
+            ->addFilter('order_id', $order->getEntityId(), 'eq')
+            ->create();
+
+        return $this->objectManager->get(InvoiceRepositoryInterface::class)->getList($searchCriteria)->getTotalCount();
+    }
+}

--- a/Test/Integration/Model/Client/Payments/CapturePaymentForInvoiceTest.php
+++ b/Test/Integration/Model/Client/Payments/CapturePaymentForInvoiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Model\Client\Payments;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Model\Order\Invoice;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\CreatePaymentCaptureRequest;
+use Mollie\Payment\Exceptions\PartialCaptureNotSupported;
+use Mollie\Payment\Model\Client\Payments\CapturePaymentForInvoice;
+use Mollie\Payment\Test\Fakes\Service\Mollie\FakeMollieApiClient;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class CapturePaymentForInvoiceTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testRefusesAPartialInvoiceWhenTheMethodDoesNotSupportPartialCaptures(): void
+    {
+        $this->fakeCaptureApi();
+
+        $instance = $this->objectManager->create(CapturePaymentForInvoice::class);
+
+        $this->expectException(PartialCaptureNotSupported::class);
+        $instance->execute($this->prepareInvoice('mollie_methods_riverty', 44.0));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCallsNoApiForARefusedPartialInvoice(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $instance = $this->objectManager->create(CapturePaymentForInvoice::class);
+
+        try {
+            $instance->execute($this->prepareInvoice('mollie_methods_riverty', 44.0));
+            $this->fail('Expected the partial invoice to be refused');
+        } catch (PartialCaptureNotSupported $exception) {
+            $fake->loadByStore()->assertSentCount(0);
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCapturesAnInvoiceThatCoversTheCompleteOrder(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $instance = $this->objectManager->create(CapturePaymentForInvoice::class);
+        $instance->execute($this->prepareInvoice('mollie_methods_riverty', 100.0));
+
+        $fake->loadByStore()->assertSent(CreatePaymentCaptureRequest::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testCapturesAPartialInvoiceWhenTheMethodSupportsPartialCaptures(): void
+    {
+        $fake = $this->fakeCaptureApi();
+
+        $instance = $this->objectManager->create(CapturePaymentForInvoice::class);
+        $instance->execute($this->prepareInvoice('mollie_methods_creditcard', 44.0));
+
+        $fake->loadByStore()->assertSent(CreatePaymentCaptureRequest::class);
+    }
+
+    private function fakeCaptureApi(): FakeMollieApiClient
+    {
+        $fake = $this->loadFakeMollieApiClient();
+        $fake->fake([
+            CreatePaymentCaptureRequest::class => MockResponse::created(
+                '{"resource":"capture","id":"cpt_dummycapture","paymentId":"tr_dummytransaction","status":"pending"}',
+            ),
+        ], true);
+
+        return $fake;
+    }
+
+    private function prepareInvoice(string $method, float $invoiceGrandTotal): InvoiceInterface
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+        $order->setMollieTransactionId('tr_dummytransaction');
+        $order->setBaseGrandTotal(100.0);
+
+        /** @var Invoice $invoice */
+        $invoice = $this->objectManager->create(Invoice::class);
+        $invoice->setOrder($order);
+        $invoice->setBaseGrandTotal($invoiceGrandTotal);
+
+        return $invoice;
+    }
+}

--- a/Test/Integration/Model/Cronjob/CleanExpiredOrdersCollectionTest.php
+++ b/Test/Integration/Model/Cronjob/CleanExpiredOrdersCollectionTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Model\Cronjob;
+
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Mollie\Payment\Model\Cronjob\CleanExpiredOrdersCollection;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class CleanExpiredOrdersCollectionTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider asyncMethodProvider
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    #[DataProvider('asyncMethodProvider')]
+    public function testExcludesOrdersPaidWithAnAsyncMethod(string $method): void
+    {
+        $orderId = $this->createOrderWithMethod($method);
+
+        $this->assertNotContains($orderId, $this->getAllIds());
+    }
+
+    public static function asyncMethodProvider(): array
+    {
+        return [
+            'banktransfer' => ['mollie_methods_banktransfer'],
+            'paybybank' => ['mollie_methods_paybybank'],
+        ];
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testIncludesOrdersPaidWithASynchronousMethod(): void
+    {
+        $orderId = $this->createOrderWithMethod('mollie_methods_ideal');
+
+        $this->assertContains($orderId, $this->getAllIds());
+    }
+
+    private function createOrderWithMethod(string $method): string
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+
+        $this->objectManager->get(OrderRepositoryInterface::class)->save($order);
+
+        return (string) $order->getEntityId();
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAllIds(): array
+    {
+        /** @var CleanExpiredOrdersCollection $collection */
+        $collection = $this->objectManager->create(CleanExpiredOrdersCollection::class);
+
+        return array_map('strval', $collection->getAllIds());
+    }
+}

--- a/Test/Integration/Observer/MollieStartTransaction/SavePendingOrderTest.php
+++ b/Test/Integration/Observer/MollieStartTransaction/SavePendingOrderTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Observer\MollieStartTransaction;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Api\PendingPaymentReminderRepositoryInterface;
+use Mollie\Payment\Observer\MollieStartTransaction\SavePendingOrder;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class SavePendingOrderTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider asyncMethodProvider
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_general/enable_second_chance_email 1
+     * @magentoConfigFixture default_store payment/mollie_general/automatically_send_second_chance_emails 1
+     */
+    #[DataProvider('asyncMethodProvider')]
+    public function testDoesNotSaveAReminderForAnAsyncMethod(string $method): void
+    {
+        $order = $this->executeForMethod($method);
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->objectManager->get(PendingPaymentReminderRepositoryInterface::class)
+            ->getByOrderId((int) $order->getEntityId());
+    }
+
+    public static function asyncMethodProvider(): array
+    {
+        return [
+            'banktransfer' => ['mollie_methods_banktransfer'],
+            'paybybank' => ['mollie_methods_paybybank'],
+        ];
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_general/enable_second_chance_email 1
+     * @magentoConfigFixture default_store payment/mollie_general/automatically_send_second_chance_emails 1
+     */
+    public function testSavesAReminderForASynchronousMethod(): void
+    {
+        $order = $this->executeForMethod('mollie_methods_ideal');
+
+        $reminder = $this->objectManager->get(PendingPaymentReminderRepositoryInterface::class)
+            ->getByOrderId((int) $order->getEntityId());
+
+        $this->assertEquals($order->getEntityId(), $reminder->getOrderId());
+    }
+
+    private function executeForMethod(string $method): OrderInterface
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+
+        $observer = $this->objectManager->create(Observer::class);
+        $observer->setData('order', $order);
+
+        $this->objectManager->create(SavePendingOrder::class)->execute($observer);
+
+        return $order;
+    }
+}

--- a/Test/Integration/Service/Mollie/AsyncPaymentMethodsTest.php
+++ b/Test/Integration/Service/Mollie/AsyncPaymentMethodsTest.php
@@ -39,4 +39,15 @@ class AsyncPaymentMethodsTest extends IntegrationTestCase
             'null' => [null, false],
         ];
     }
+
+    public function testAllCodesReturnsThePaymentMethodCodes(): void
+    {
+        /** @var AsyncPaymentMethods $instance */
+        $instance = $this->objectManager->get(AsyncPaymentMethods::class);
+
+        $this->assertEquals(
+            ['mollie_methods_banktransfer', 'mollie_methods_paybybank'],
+            $instance->allCodes(),
+        );
+    }
 }

--- a/Test/Integration/Service/Mollie/CreateSessionTest.php
+++ b/Test/Integration/Service/Mollie/CreateSessionTest.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace Mollie\Payment\Test\Integration\Service\Mollie;
 
+use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\TestFramework\Quote\Model\GetQuoteByReservedOrderId;
 use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Data\Money;
 use Mollie\Api\Http\PendingRequest;
 use Mollie\Api\MollieApiClient;
 use Mollie\Payment\Service\Mollie\Api\CreateSessionRequest;
@@ -74,6 +76,55 @@ class CreateSessionTest extends IntegrationTestCase
         });
     }
 
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address_and_shipping_method_saved.php
+     */
+    public function testChargesTheGrandTotalIncludingShippingOnTheCheckoutPath(): void
+    {
+        $client = $this->fakeSessionRequest();
+
+        $cart = $this->loadQuote();
+        $shippingCosts = (float)$cart->getShippingAddress()->getShippingInclTax();
+        $grandTotal = (float)$this->objectManager->get(CartTotalRepositoryInterface::class)
+            ->get($cart->getId())
+            ->getGrandTotal();
+
+        $this->assertGreaterThan(0, $shippingCosts, 'The quote must have shipping costs for this test to be useful');
+
+        /** @var CreateSession $instance */
+        $instance = $this->objectManager->create(CreateSession::class);
+        $instance->execute($cart, false);
+
+        $client->assertSent(function (PendingRequest $request) use ($grandTotal): bool {
+            $this->assertSame(number_format($grandTotal, 2, '.', ''), $this->extractAmount($request)['value']);
+
+            return true;
+        });
+    }
+
+    /**
+     * @magentoDataFixture Magento/Checkout/_files/quote_with_address_and_shipping_method_saved.php
+     */
+    public function testExpressPathChargesTheSubtotal(): void
+    {
+        $client = $this->fakeSessionRequest();
+
+        $cart = $this->loadQuote();
+        $subtotal = (float)$this->objectManager->get(CartTotalRepositoryInterface::class)
+            ->get($cart->getId())
+            ->getSubtotalInclTax();
+
+        /** @var CreateSession $instance */
+        $instance = $this->objectManager->create(CreateSession::class);
+        $instance->execute($cart, true);
+
+        $client->assertSent(function (PendingRequest $request) use ($subtotal): bool {
+            $this->assertSame(number_format($subtotal, 2, '.', ''), $this->extractAmount($request)['value']);
+
+            return true;
+        });
+    }
+
     private function fakeSessionRequest(): MollieApiClient
     {
         $client = MollieApiClient::fake([
@@ -98,6 +149,20 @@ class CreateSessionTest extends IntegrationTestCase
         $body = json_decode((string)$request->createPsrRequest()->getBody(), true);
 
         return $body['lines'] ?? [];
+    }
+
+    private function extractAmount(PendingRequest $request): array
+    {
+        $payload = $request->payload();
+        if ($payload !== null) {
+            $amount = $payload->all()['amount'] ?? null;
+
+            return $amount instanceof Money ? $amount->toArray() : (array)$amount;
+        }
+
+        $body = json_decode((string)$request->createPsrRequest()->getBody(), true);
+
+        return $body['amount'] ?? [];
     }
 
     private function loadQuote(): CartInterface

--- a/Test/Integration/Service/Mollie/Customer/ForgetMollieCustomerIdTest.php
+++ b/Test/Integration/Service/Mollie/Customer/ForgetMollieCustomerIdTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie\Customer;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Api\Data\MollieCustomerInterface;
+use Mollie\Payment\Service\Mollie\Customer\ForgetMollieCustomerId;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class ForgetMollieCustomerIdTest extends IntegrationTestCase
+{
+    /**
+     * Deliberately different from the customer ID, as the row has to be removed by its own primary key.
+     */
+    private const ENTITY_ID = 4200;
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testRemovesTheStoredMollieCustomer(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $this->storeMollieCustomerId((int)$order->getCustomerId(), 'cst_no_longer_available');
+
+        /** @var ForgetMollieCustomerId $instance */
+        $instance = $this->objectManager->create(ForgetMollieCustomerId::class);
+
+        $this->assertTrue($instance->execute($order));
+        $this->assertEquals(0, $this->countStoredMollieCustomers((int)$order->getCustomerId()));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testStopsExposingTheMollieCustomerIdOnTheCustomer(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $this->storeMollieCustomerId((int)$order->getCustomerId(), 'cst_no_longer_available');
+
+        /** @var ForgetMollieCustomerId $instance */
+        $instance = $this->objectManager->create(ForgetMollieCustomerId::class);
+
+        $this->assertEquals('cst_no_longer_available', $this->getMollieCustomerIdAttribute($order));
+
+        $instance->execute($order);
+
+        $this->assertNull($this->getMollieCustomerIdAttribute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testReturnsFalseWhenNothingIsStored(): void
+    {
+        $order = $this->loadOrder('100000001');
+
+        /** @var ForgetMollieCustomerId $instance */
+        $instance = $this->objectManager->create(ForgetMollieCustomerId::class);
+
+        $this->assertFalse($instance->execute($order));
+    }
+
+    public function testReturnsFalseWhenTheOrderHasNoCustomer(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+
+        /** @var ForgetMollieCustomerId $instance */
+        $instance = $this->objectManager->create(ForgetMollieCustomerId::class);
+
+        $this->assertFalse($instance->execute($order));
+    }
+
+    private function storeMollieCustomerId(int $customerId, string $mollieCustomerId): void
+    {
+        /** @var ResourceConnection $resource */
+        $resource = $this->objectManager->get(ResourceConnection::class);
+
+        $resource->getConnection()->insert($resource->getTableName('mollie_payment_customer'), [
+            MollieCustomerInterface::ENTITY_ID => static::ENTITY_ID,
+            MollieCustomerInterface::CUSTOMER_ID => $customerId,
+            MollieCustomerInterface::MOLLIE_CUSTOMER_ID => $mollieCustomerId,
+        ]);
+    }
+
+    private function getMollieCustomerIdAttribute(OrderInterface $order): ?string
+    {
+        $customer = $this->objectManager->create(CustomerRepositoryInterface::class)
+            ->getById((int)$order->getCustomerId());
+
+        return $customer->getExtensionAttributes()->getMollieCustomerId();
+    }
+
+    private function countStoredMollieCustomers(int $customerId): int
+    {
+        /** @var ResourceConnection $resource */
+        $resource = $this->objectManager->get(ResourceConnection::class);
+        $connection = $resource->getConnection();
+
+        $select = $connection->select()
+            ->from($resource->getTableName('mollie_payment_customer'), 'COUNT(*)')
+            ->where(MollieCustomerInterface::CUSTOMER_ID . ' = ?', $customerId);
+
+        return (int)$connection->fetchOne($select);
+    }
+}

--- a/Test/Integration/Service/Mollie/Order/SupportsPartialCaptureTest.php
+++ b/Test/Integration/Service/Mollie/Order/SupportsPartialCaptureTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie\Order;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Service\Mollie\Order\SupportsPartialCapture;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class SupportsPartialCaptureTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testReturnsTrueForAMethodThatSupportsPartialCaptures(): void
+    {
+        $order = $this->prepareOrder('mollie_methods_creditcard', 'tr_dummytransaction');
+
+        $instance = $this->objectManager->create(SupportsPartialCapture::class);
+
+        $this->assertTrue($instance->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testReturnsFalseForRiverty(): void
+    {
+        $order = $this->prepareOrder('mollie_methods_riverty', 'tr_dummytransaction');
+
+        $instance = $this->objectManager->create(SupportsPartialCapture::class);
+
+        $this->assertFalse($instance->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testReturnsFalseForBillink(): void
+    {
+        $order = $this->prepareOrder('mollie_methods_billink', 'tr_dummytransaction');
+
+        $instance = $this->objectManager->create(SupportsPartialCapture::class);
+
+        $this->assertFalse($instance->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testReturnsTrueForALegacyOrdersApiTransactionThatCanShipSeparateLines(): void
+    {
+        $order = $this->prepareOrder('mollie_methods_riverty', 'ord_dummytransaction');
+
+        $instance = $this->objectManager->create(SupportsPartialCapture::class);
+
+        $this->assertTrue($instance->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_methods_riverty/supports_partial_capture 1
+     */
+    public function testFollowsTheStoreConfiguration(): void
+    {
+        $order = $this->prepareOrder('mollie_methods_riverty', 'tr_dummytransaction');
+
+        $instance = $this->objectManager->create(SupportsPartialCapture::class);
+
+        $this->assertTrue($instance->execute($order));
+    }
+
+    private function prepareOrder(string $method, string $transactionId): OrderInterface
+    {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+        $order->setMollieTransactionId($transactionId);
+
+        return $order;
+    }
+}

--- a/Test/Integration/Service/Mollie/Order/ValidatePartialCaptureTest.php
+++ b/Test/Integration/Service/Mollie/Order/ValidatePartialCaptureTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie\Order;
+
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Model\Order\Invoice;
+use Mollie\Payment\Exceptions\PartialCaptureNotSupported;
+use Mollie\Payment\Service\Mollie\Order\ValidatePartialCapture;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class ValidatePartialCaptureTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testThrowsWhenTheMethodDoesNotSupportPartialCaptures(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 44.0);
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+
+        $this->expectException(PartialCaptureNotSupported::class);
+        $instance->execute($invoice);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testMentionsTheMethodTitleAndHowToContinue(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 44.0);
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+
+        $this->expectExceptionMessage(
+            'Riverty does not support partial captures. Create a single invoice or shipment for the complete order, '
+            . 'or cancel the order to release the authorization.'
+        );
+        $instance->execute($invoice);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testAcceptsAnInvoiceThatCoversTheCompleteOrder(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 100.0);
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+        $instance->execute($invoice);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testAcceptsAPartialInvoiceForAMethodThatSupportsPartialCaptures(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_creditcard', 44.0);
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+        $instance->execute($invoice);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testAcceptsAPartialInvoiceForALegacyOrdersApiTransaction(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 44.0, 100.0, 'ord_dummytransaction');
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+        $instance->execute($invoice);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The invoice total is accumulated by unrounded float additions in Magento's total collectors, while the order
+     * total comes back from a decimal column as a string. Both represent the same amount of money.
+     *
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testAcceptsAnInvoiceThatDiffersFromTheOrderInTheLastFloatingPointDigit(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 615.06 + 2.15 + 129.61, '746.8200');
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+        $instance->execute($invoice);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testStillRefusesAPartialInvoiceOnAnOrderWithShippingAndTax(): void
+    {
+        $invoice = $this->prepareInvoice('mollie_methods_riverty', 615.06, '746.8200');
+
+        $instance = $this->objectManager->create(ValidatePartialCapture::class);
+
+        $this->expectException(PartialCaptureNotSupported::class);
+        $instance->execute($invoice);
+    }
+
+    private function prepareInvoice(
+        string $method,
+        float $invoiceGrandTotal,
+        string|float $orderGrandTotal = 100.0,
+        string $transactionId = 'tr_dummytransaction',
+    ): InvoiceInterface {
+        $order = $this->loadOrderById('100000001');
+        $order->getPayment()->setMethod($method);
+        $order->setMollieTransactionId($transactionId);
+        $order->setBaseGrandTotal($orderGrandTotal);
+
+        /** @var Invoice $invoice */
+        $invoice = $this->objectManager->create(Invoice::class);
+        $invoice->setOrder($order);
+        $invoice->setBaseGrandTotal($invoiceGrandTotal);
+
+        return $invoice;
+    }
+}

--- a/Test/Integration/Service/Mollie/StartTransactionTest.php
+++ b/Test/Integration/Service/Mollie/StartTransactionTest.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\Fake\MockResponse;
+use Mollie\Api\Http\Requests\GetPaymentRequest;
+use Mollie\Payment\Api\Data\MollieCustomerInterface;
+use Mollie\Payment\Api\MollieCustomerRepositoryInterface;
+use Mollie\Payment\Model\Client\Payments;
+use Mollie\Payment\Service\Mollie\StartTransaction;
+use Mollie\Payment\Test\Fakes\Service\Mollie\FakeMollieApiClient;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class StartTransactionTest extends IntegrationTestCase
+{
+    private const CHECKOUT_URL = 'https://www.mollie.com/checkout/select-method/abc123';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The OrderLockService interferes with the tests, so we replace it with a fake.
+        $this->loadFakeOrderLockService();
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testRemovesTheMollieCustomerAndRetriesWhenItNoLongerExists(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $this->storeMollieCustomerId($order, 'cst_no_longer_available');
+
+        $paymentsApiMock = $this->createMock(Payments::class);
+        $paymentsApiMock->expects($this->exactly(2))->method('startTransaction')->willReturnOnConsecutiveCalls(
+            $this->throwException($this->createApiException(410, 'Gone', 'The customer is no longer available')),
+            static::CHECKOUT_URL,
+        );
+
+        $result = $this->createInstance($paymentsApiMock)->execute($order);
+
+        $this->assertEquals(static::CHECKOUT_URL, $result);
+        $this->assertNull($this->getMollieCustomer($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testKeepsTheMollieCustomerWhenTheErrorIsUnrelated(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $this->storeMollieCustomerId($order, 'cst_still_valid');
+
+        $exception = $this->createApiException(422, 'Unprocessable Entity', 'The amount is invalid');
+
+        $paymentsApiMock = $this->createMock(Payments::class);
+        $paymentsApiMock->expects($this->once())->method('startTransaction')->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+
+        try {
+            $this->createInstance($paymentsApiMock)->execute($order);
+        } finally {
+            $this->assertNotNull($this->getMollieCustomer($order));
+        }
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order_with_customer.php
+     */
+    public function testDoesNotRetryWhenThereIsNoMollieCustomerStored(): void
+    {
+        $order = $this->loadOrder('100000001');
+
+        $exception = $this->createApiException(410, 'Gone', 'The customer is no longer available');
+
+        $paymentsApiMock = $this->createMock(Payments::class);
+        $paymentsApiMock->expects($this->once())->method('startTransaction')->willThrowException($exception);
+
+        $this->expectExceptionObject($exception);
+
+        $this->createInstance($paymentsApiMock)->execute($order);
+    }
+
+    private function createInstance(Payments $paymentsApi): StartTransaction
+    {
+        $apiClient = $this->objectManager->create(FakeMollieApiClient::class);
+        $apiClient->setInstance(new \Mollie\Api\MollieApiClient());
+
+        return $this->objectManager->create(StartTransaction::class, [
+            'paymentsApi' => $paymentsApi,
+            'mollieApiClient' => $apiClient,
+        ]);
+    }
+
+    private function createApiException(int $status, string $title, string $detail): ApiException
+    {
+        $client = \Mollie\Api\MollieApiClient::fake([
+            GetPaymentRequest::class => MockResponse::error($status, $title, $detail),
+        ]);
+
+        try {
+            $client->send(new GetPaymentRequest('tr_dummy'));
+        } catch (ApiException $exception) {
+            return $exception;
+        }
+
+        $this->fail('Expected the faked request to result in an ApiException');
+    }
+
+    private function storeMollieCustomerId(OrderInterface $order, string $mollieCustomerId): void
+    {
+        /** @var ResourceConnection $resource */
+        $resource = $this->objectManager->get(ResourceConnection::class);
+
+        $resource->getConnection()->insert($resource->getTableName('mollie_payment_customer'), [
+            MollieCustomerInterface::CUSTOMER_ID => (int)$order->getCustomerId(),
+            MollieCustomerInterface::MOLLIE_CUSTOMER_ID => $mollieCustomerId,
+        ]);
+    }
+
+    private function getMollieCustomer(OrderInterface $order): ?MollieCustomerInterface
+    {
+        $customer = $this->objectManager->get(CustomerRepositoryInterface::class)
+            ->getById((int)$order->getCustomerId());
+
+        return $this->objectManager->get(MollieCustomerRepositoryInterface::class)->getByCustomer($customer);
+    }
+}

--- a/Test/Integration/Setup/Patch/Data/RenameIdealToIdealWeroTest.php
+++ b/Test/Integration/Setup/Patch/Data/RenameIdealToIdealWeroTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Setup\Patch\Data;
+
+use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Mollie\Payment\Setup\Patch\Data\RenameIdealToIdealWero;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class RenameIdealToIdealWeroTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDbIsolation enabled
+     */
+    public function testUpdatesTheDefaultIdealTitle(): void
+    {
+        $this->saveTitle('iDeal');
+
+        $this->applyPatch();
+
+        $this->assertEquals('iDeal | Wero', $this->readTitle());
+    }
+
+    /**
+     * @magentoDbIsolation enabled
+     */
+    public function testLeavesCustomizedTitlesUntouched(): void
+    {
+        $this->saveTitle('iDEAL + €1');
+
+        $this->applyPatch();
+
+        $this->assertEquals('iDEAL + €1', $this->readTitle());
+    }
+
+    private function saveTitle(string $title): void
+    {
+        $this->objectManager->get(WriterInterface::class)
+            ->save('payment/mollie_methods_ideal/title', $title);
+    }
+
+    private function applyPatch(): void
+    {
+        $this->objectManager->create(RenameIdealToIdealWero::class)->apply();
+    }
+
+    private function readTitle(): string
+    {
+        $collection = $this->objectManager->create(CollectionFactory::class)->create()
+            ->addFieldToFilter('path', ['eq' => 'payment/mollie_methods_ideal/title']);
+
+        return (string)$collection->getFirstItem()->getData('value');
+    }
+}

--- a/Test/Integration/etc/adminhtml/methods/ManualCaptureConfigurationTest.php
+++ b/Test/Integration/etc/adminhtml/methods/ManualCaptureConfigurationTest.php
@@ -39,6 +39,35 @@ class ManualCaptureConfigurationTest extends AbstractXmlConfiguration
         }
     }
 
+    public function testEveryMethodDeclaresWhetherItSupportsPartialCaptures(): void
+    {
+        $configXml = $this->getGeneralXmlConfigFile();
+
+        foreach ($configXml->default->payment->children() as $groupName => $config) {
+            if (!str_starts_with($groupName, 'mollie_methods_')) {
+                continue;
+            }
+
+            $this->assertTrue(
+                isset($config->supports_partial_capture),
+                sprintf('Method group "%s" does not declare supports_partial_capture', $groupName)
+            );
+        }
+    }
+
+    public function testRivertyAndBillinkDoNotSupportPartialCaptures(): void
+    {
+        $configXml = $this->getGeneralXmlConfigFile();
+
+        foreach (['riverty', 'billink'] as $method) {
+            $this->assertSame(
+                '0',
+                (string) $configXml->default->payment->{'mollie_methods_' . $method}->supports_partial_capture,
+                sprintf('Method "%s" should not allow partial captures', $method)
+            );
+        }
+    }
+
     public function testGooglePaySupportsManualCaptureConfiguration(): void
     {
         $configXml = $this->getGeneralXmlConfigFile();

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "mollie/magento2",
   "description": "Mollie Payment Module for Magento 2",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "keywords": [
     "mollie",
     "payment",

--- a/docs/en/ORDER_MANAGEMENT.md
+++ b/docs/en/ORDER_MANAGEMENT.md
@@ -56,6 +56,14 @@ For Klarna and Billie, the default is **On shipment**, which matches the buy-now
 
 Cancelling an order that has not been fully captured releases the remaining authorisation at Mollie automatically, so the reserved amount is returned to the customer without waiting for the expiration window. If the release request fails, the order is still cancelled in Magento and a warning is shown in Magento Admin; Mollie then releases the uncaptured amount itself when the authorisation expires.
 
+### Methods Without Partial Captures
+
+**Riverty** and **Billink** can only capture the complete order amount at once. Whichever action triggers the capture — creating the invoice or creating the shipment, depending on **When to capture?** — is refused with an error in Magento Admin if it does not cover the complete order, and nothing is created. A notice is shown on that page as a reminder.
+
+To ship or invoice such an order, include every item in a single invoice or shipment. If you cannot deliver the complete order, cancel it instead so the authorisation is released, and place a new order for the items you can deliver.
+
+Note that Riverty and Billink ship without a default for **When to capture?**. Until you set it, no capture is triggered at all and the authorisation expires on its own, so set it before taking these methods live.
+
 ### Automatic Capture Delay
 
 For methods using **Autocapture**, you can insert a delay between authorisation and capture. This gives you a window to review or cancel orders before the customer is charged.

--- a/docs/nl/ORDER_MANAGEMENT.md
+++ b/docs/nl/ORDER_MANAGEMENT.md
@@ -56,6 +56,14 @@ Voor Klarna en Billie is de standaard **On shipment**, wat overeenkomt met de ko
 
 Het annuleren van een order die nog niet volledig is gecaptured, geeft de resterende autorisatie bij Mollie automatisch vrij, zodat het gereserveerde bedrag terugkeert naar de klant zonder het vervaltijdvenster af te wachten. Als het vrijgaveverzoek mislukt, wordt de order alsnog geannuleerd in Magento en verschijnt een waarschuwing in Magento Admin; Mollie geeft het niet-gecapturede bedrag dan zelf vrij wanneer de autorisatie verloopt.
 
+### Methodes zonder gedeeltelijke captures
+
+**Riverty** en **Billink** kunnen alleen het volledige orderbedrag in één keer capturen. De actie die de capture start — het aanmaken van de factuur of van de verzending, afhankelijk van **When to capture?** — wordt geweigerd met een foutmelding in Magento Admin als deze niet de volledige order dekt, en er wordt niets aangemaakt. Op die pagina verschijnt ter herinnering een melding.
+
+Neem alle artikelen op in één factuur of verzending om zo'n order te factureren of te verzenden. Kun je de order niet volledig leveren, annuleer deze dan zodat de autorisatie wordt vrijgegeven, en plaats een nieuwe order voor de artikelen die je wel kunt leveren.
+
+Let op: Riverty en Billink hebben geen standaardwaarde voor **When to capture?**. Zolang je deze niet instelt wordt er helemaal geen capture gestart en verloopt de autorisatie vanzelf, dus stel dit in voordat je deze methodes live zet.
+
 ### Vertraging bij automatische capture
 
 Voor methoden die **Autocapture** gebruiken, kun je een vertraging invoegen tussen autorisatie en capture. Dit geeft je een venster om orders te controleren of te annuleren voordat de klant wordt belast.

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -52,6 +52,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -76,6 +77,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -96,6 +98,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -114,6 +117,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -132,6 +136,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -152,6 +157,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -170,6 +176,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -188,6 +195,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -208,6 +216,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>0</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -228,6 +237,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -246,6 +256,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -264,6 +275,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -290,6 +302,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -308,6 +321,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -327,6 +341,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -346,6 +361,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>0</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -365,6 +381,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -388,6 +405,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -406,6 +424,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -425,6 +444,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -443,6 +463,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -462,6 +483,7 @@
                 <can_order>0</can_order>
                 <can_refund>0</can_refund>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnapaylater>
             <mollie_methods_klarnapaynow>
                 <active>0</active>
@@ -473,6 +495,7 @@
                 <can_order>0</can_order>
                 <can_refund>0</can_refund>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnapaynow>
             <mollie_methods_klarnasliceit>
                 <active>0</active>
@@ -484,6 +507,7 @@
                 <can_order>0</can_order>
                 <can_refund>0</can_refund>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnasliceit>
             <mollie_methods_mbway>
                 <active>1</active>
@@ -498,6 +522,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -517,6 +542,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -537,6 +563,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -555,6 +582,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -575,6 +603,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>1</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -594,6 +623,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -612,6 +642,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -631,6 +662,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -649,6 +681,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>1</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -667,6 +700,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -685,6 +719,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -703,6 +738,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>0</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>1</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -722,6 +758,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -740,6 +777,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -758,6 +796,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -776,6 +815,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -794,6 +834,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -813,6 +854,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -833,6 +875,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>1</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -852,6 +895,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>
@@ -871,6 +915,7 @@
                 <can_refund>1</can_refund>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
+                <supports_partial_capture>1</supports_partial_capture>
                 <can_cancel>1</can_cancel>
                 <can_authorize>0</can_authorize>
                 <can_authorize_vault>0</can_authorize_vault>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -9,7 +9,7 @@
     <default>
         <payment>
             <mollie_general>
-                <version>v3.1.1</version>
+                <version>v3.1.2</version>
                 <active>0</active>
                 <enabled>0</enabled>
                 <type>test</type>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -1,4 +1,5 @@
 """%1"" does not implement %1","""%1"" does not implement %1"
+"%1 does not support partial captures. Create a single invoice or shipment for the complete order, or cancel the order to release the authorization.","%1 does not support partial captures. Create a single invoice or shipment for the complete order, or cancel the order to release the authorization."
 "%1 hours","%1 hours"
 "%1 using Voucher, %2 direct.","%1 using Voucher, %2 direct."
 "-- Please Select --","-- Please Select --"
@@ -11,6 +12,7 @@
 <strong>Store Locale</strong>: Use the locale active in the current store or fall back to English if this can't be determined."
 "<strong>Description:</strong> Order #%order_id from %store_name","<strong>Description:</strong> Order #%order_id from %store_name"
 "<strong>Optional:</strong> Comma-separated list of email addresses. Leave empty to disable.","<strong>Optional:</strong> Comma-separated list of email addresses. Leave empty to disable."
+"Please note: %1 does not support partial captures. Only the complete order can be captured, so a partial invoice or shipment will be refused.","Please note: %1 does not support partial captures. Only the complete order can be captured, so a partial invoice or shipment will be refused."
 "[TEST] An error occured","[TEST] An error occured"
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method."
 "Actions","Actions"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -1,4 +1,5 @@
 """%1"" does not implement %1","""%1"" implementeert %1 niet"
+"%1 does not support partial captures. Create a single invoice or shipment for the complete order, or cancel the order to release the authorization.","%1 ondersteunt geen gedeeltelijke captures. Maak één factuur of verzending aan voor de volledige order, of annuleer de order om de autorisatie vrij te geven."
 "%1 hours","%1 uur"
 "%1 using Voucher, %2 direct.","%1 met Voucher, %2 direct."
 "-- Please Select --","-- Selecteer --"
@@ -11,6 +12,7 @@
 <strong>Winkellocatie</strong>: Gebruik de taal die actief is in de huidige winkel, of val terug op Engels als dit niet bepaald kan worden."
 "<strong>Description:</strong> Order #%order_id from %store_name","<strong>Beschrijving:</strong> Bestelling #%order_id bij %store_name"
 "<strong>Optional:</strong> Comma-separated list of email addresses. Leave empty to disable.","<strong>Optioneel:</strong> Door komma's gescheiden lijst van e-mailadressen. Laat leeg om uit te schakelen."
+"Please note: %1 does not support partial captures. Only the complete order can be captured, so a partial invoice or shipment will be refused.","Let op: %1 ondersteunt geen gedeeltelijke captures. Alleen de volledige order kan worden gecaptured, dus een gedeeltelijke factuur of verzending wordt geweigerd."
 "[TEST] An error occured","[TEST] Er is een fout opgetreden."
 "A Timeout while connecting to %1 occurred, this could be the result of an outage. Please try again or select another payment method.","Er is een time-out opgetreden tijdens de verbinding met %1, dit kan het gevolg zijn van een storing. Probeer het opnieuw of kies een andere betaalmethode."
 "Actions","Acties"

--- a/view/adminhtml/layout/sales_order_invoice_new.xml
+++ b/view/adminhtml/layout/sales_order_invoice_new.xml
@@ -4,25 +4,16 @@
   ~ See COPYING.txt for license details.
   -->
 
-<!--
-/**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
- */
--->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="submit_before">
-            <block template="Mollie_Payment::order/shipment/create/payment_hold_warning.phtml"
-                   name="mollie.payment.hold.warning"
-            />
             <block class="Mollie\Payment\Block\Adminhtml\Sales\Order\PartialCaptureNotSupportedNotice"
                    template="Mollie_Payment::order/partial_capture_not_supported.phtml"
                    name="mollie.partial.capture.not.supported"
             >
                 <arguments>
-                    <argument name="registry_key" xsi:type="string">current_shipment</argument>
-                    <argument name="capture_moment" xsi:type="string">shipment</argument>
+                    <argument name="registry_key" xsi:type="string">current_invoice</argument>
+                    <argument name="capture_moment" xsi:type="string">invoice</argument>
                 </arguments>
             </block>
         </referenceContainer>

--- a/view/adminhtml/layout/sales_order_invoice_updateqty.xml
+++ b/view/adminhtml/layout/sales_order_invoice_updateqty.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Magmodules.eu. All rights reserved.
+  ~ See COPYING.txt for license details.
+  -->
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="order_items">
+            <container name="submit_before" label="Submit Before">
+                <block class="Mollie\Payment\Block\Adminhtml\Sales\Order\PartialCaptureNotSupportedNotice"
+                       template="Mollie_Payment::order/partial_capture_not_supported.phtml"
+                       name="mollie.partial.capture.not.supported"
+                >
+                    <arguments>
+                        <argument name="registry_key" xsi:type="string">current_invoice</argument>
+                        <argument name="capture_moment" xsi:type="string">invoice</argument>
+                    </arguments>
+                </block>
+            </container>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/adminhtml/templates/order/partial_capture_not_supported.phtml
+++ b/view/adminhtml/templates/order/partial_capture_not_supported.phtml
@@ -1,0 +1,17 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Mollie\Payment\Block\Adminhtml\Sales\Order\PartialCaptureNotSupportedNotice;
+
+/** @var PartialCaptureNotSupportedNotice $block */
+/** @var Escaper $escaper */
+?>
+<div class="mollie-partial-capture-not-supported message message-notice notice">
+    <?= $escaper->escapeHtml($block->getMessage()); ?>
+</div>

--- a/view/frontend/web/js/view/payment/express-components.js
+++ b/view/frontend/web/js/view/payment/express-components.js
@@ -17,49 +17,117 @@ define([
     quote,
     resourceUrlManager,
 ) {
-    let sessionCreated = false;
+    'use strict';
+
     const enabled = window.checkoutConfig.payment.mollie?.expresscomponents?.enabled ?? true;
+    const PLACEMENT_CHECKOUT = 'checkout';
 
     return Component.extend({
         defaults: {
             isEnabled: enabled,
             placement: null,
+            elementId: 'express-component',
         },
 
-        createSession() {
-            if (sessionCreated) {
+        initialize: function () {
+            this._super();
+
+            this.requestedAmount = null;
+            this.hasPendingRequest = false;
+
+            quote.totals.subscribe(() => this.createSession());
+        },
+
+        createSession: function () {
+            if (this.hasPendingRequest || !this.canCreateSession()) {
                 return;
             }
 
-            let interval = setInterval( function () {
-                let data = {};
-                if (resourceUrlManager.getCheckoutMethod() === 'guest' && !quote.guestEmail) {
-                    return;
-                }
+            const amount = this.getSessionAmount();
+            if (amount === null || amount === this.requestedAmount) {
+                return;
+            }
 
-                if (resourceUrlManager.getCheckoutMethod() === 'guest') {
-                    data = {
-                        email: quote.guestEmail,
-                    };
-                }
+            this.requestedAmount = amount;
+            this.hasPendingRequest = true;
 
-                clearInterval(interval);
-                sessionCreated = true;
+            $.ajax({
+                global: false,
+                context: this,
+                type: 'POST',
+                data: this.getRequestData(),
+                url: this.getCreateSessionUrl(),
+                success: function (result) {
+                    this.initializeExpressComponent(result);
+                }.bind(this),
+                error: function () {
+                    this.requestedAmount = null;
+                }.bind(this),
+                complete: function () {
+                    this.hasPendingRequest = false;
+                }.bind(this),
+            });
+        },
 
-                $.ajax({
-                    global: false,
-                    context: this,
-                    type: 'POST',
-                    data: data,
-                    url: url.build('mollie/express/createSession/type/checkout'),
-                    success: function (result) {
-                        this.initializeExpressComponent(result);
-                    }.bind(this),
-                });
-            }.bind(this), 1000);
+        canCreateSession: function () {
+            if (!this.isEnabled) {
+                return false;
+            }
+
+            if (this.isGuest() && !quote.guestEmail) {
+                return false;
+            }
+
+            return !this.isWaitingForShippingMethod();
+        },
+
+        /*
+         * In the checkout the session amount is the grand total, which only includes the shipping costs after the
+         * customer has selected a shipping method. Creating the session before that charges the subtotal only.
+         */
+        isWaitingForShippingMethod: function () {
+            return this.isCheckoutPlacement() && !quote.isVirtual() && !quote.shippingMethod();
+        },
+
+        getSessionAmount: function () {
+            const totals = quote.totals();
+            if (!totals) {
+                return null;
+            }
+
+            const amount = this.isCheckoutPlacement() ? totals.grand_total : totals.subtotal_incl_tax;
+
+            return amount === undefined ? null : amount;
+        },
+
+        getCreateSessionUrl: function () {
+            if (!this.placement) {
+                return url.build('mollie/express/createSession');
+            }
+
+            return url.build('mollie/express/createSession/type/' + this.placement);
+        },
+
+        getRequestData: function () {
+            return this.isGuest() ? {email: quote.guestEmail} : {};
+        },
+
+        isGuest: function () {
+            return resourceUrlManager.getCheckoutMethod() === 'guest';
+        },
+
+        isCheckoutPlacement: function () {
+            return this.placement === PLACEMENT_CHECKOUT;
         },
 
         initializeExpressComponent: function (result) {
+            const container = document.getElementById(this.elementId);
+            if (!container) {
+                return;
+            }
+
+            container.innerHTML = '';
+
             const checkout = Mollie.Checkout(result.clientAccessToken)
             let configuration = {
                 buttons: {
@@ -69,7 +137,7 @@ define([
                 }
             };
 
-            if (this.placement === 'cart') {
+            if (!this.isCheckoutPlacement()) {
                 configuration.paymentMethods = {
                     applepay: 'never',
                     googlepay: 'never',
@@ -77,7 +145,7 @@ define([
             }
 
             const expressComponent = checkout.create('express-checkout', configuration);
-            expressComponent.mount(document.getElementById("express-component"))
+            expressComponent.mount(container)
         }
     })
 })

--- a/view/frontend/web/js/view/payment/method-renderer/applepay-direct.js
+++ b/view/frontend/web/js/view/payment/method-renderer/applepay-direct.js
@@ -138,9 +138,9 @@ define(
             afterPlaceOrder: function () {
                 this.session.completePayment(ApplePaySession.STATUS_SUCCESS);
 
-                var paymentToken = this.paymentToken();
+                var redirectUrl = this.getRedirectUrl();
                 setTimeout( function () {
-                    window.location = url.build('mollie/checkout/redirect/paymentToken/' + paymentToken);
+                    window.location = redirectUrl;
                 }, 1000);
             }
         });

--- a/view/frontend/web/js/view/payment/method-renderer/default.js
+++ b/view/frontend/web/js/view/payment/method-renderer/default.js
@@ -5,6 +5,7 @@ define(
         'ko',
         'mage/url',
         'mage/storage',
+        'mage/translate',
         'Magento_Checkout/js/view/payment/default',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/checkout-data',
@@ -19,6 +20,7 @@ define(
         ko,
         url,
         storage,
+        $t,
         Component,
         quote,
         checkoutData,
@@ -75,10 +77,26 @@ define(
                 placeOrder: function (data, event) {
                     this.isPlaceOrderActionAllowed(false);
                     var parent = this._super.bind(this);
-                    this.beforePlaceOrder().always(function () {
+                    this.beforePlaceOrder().done(function (response) {
                         this.isPlaceOrderActionAllowed(true);
+
+                        if (!this.paymentToken()) {
+                            this.onPaymentTokenFailed(response);
+                            return;
+                        }
+
                         parent(data, event);
+                    }.bind(this)).fail(function (response) {
+                        this.isPlaceOrderActionAllowed(true);
+                        this.onPaymentTokenFailed(response);
                     }.bind(this));
+                },
+                onPaymentTokenFailed: function (response) {
+                    console.error('Mollie: unable to retrieve the payment token, the order has not been placed.', response);
+
+                    this.messageContainer.addErrorMessage({
+                        message: $t('We were unable to start your payment. Please try again.')
+                    });
                 },
                 beforePlaceOrder: function () {
                     var serviceUrl;
@@ -104,7 +122,19 @@ define(
                 },
                 afterPlaceOrder: function () {
                     this._super();
-                    window.location = url.build('mollie/checkout/redirect/paymentToken/' + this.paymentToken());
+
+                    window.location = this.getRedirectUrl();
+                },
+                /**
+                 * Without a token the redirect controller falls back to the last order of the checkout session,
+                 * so an order is never left behind unpaid when the payment token could not be retrieved.
+                 */
+                getRedirectUrl: function () {
+                    if (!this.paymentToken()) {
+                        return url.build('mollie/checkout/redirect');
+                    }
+
+                    return url.build('mollie/checkout/redirect/paymentToken/' + this.paymentToken());
                 },
                 renderMessages: function () {
                     // Copied from Magento_Theme/js/view/messages


### PR DESCRIPTION
* Bugfix: Update payment reminder onclick action - Thanks @reense
* Bugfix: Handle numeric string scope_id in RenameIdealToIdealWero patch #1046
* Bugfix: Do not auto cancel or remind async Pay by Bank orders
* Bugfix: Recreate the Mollie customer when it no longer exists due to API key change- #1189
* Bugfix: Do not place an order when the payment token could not be retrieved
* Bugfix: Prevent invalid city from blocking Apple Pay express orders
* Bugfix: Wait for the shipping method before creating the express session
* Improvement: Expose default selected method value
* Improvement: Prevent partial captures for payment methods that do not support them
