### PR TITLE
Bugfix: Prevent a repeated webhook from reopening a refunded order

### DIFF
--- a/Model/Client/Payments/ProcessTransaction.php
+++ b/Model/Client/Payments/ProcessTransaction.php
@@ -10,6 +10,7 @@ namespace Mollie\Payment\Model\Client\Payments;
 
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Api\Types\PaymentStatus;
 use Mollie\Payment\Helper\General as MollieHelper;
 use Mollie\Payment\Model\Client\ProcessTransactionResponse;
 use Mollie\Payment\Model\Client\ProcessTransactionResponseFactory;
@@ -54,7 +55,9 @@ class ProcessTransaction
             $response,
         );
 
-        if (in_array($status, ['paid', 'authorized'])) {
+        $isPaid = in_array($status, [PaymentStatus::PAID, PaymentStatus::AUTHORIZED], true);
+
+        if ($isPaid) {
             $response = $this->paymentProcessors->process(
                 'paid',
                 $magentoOrder,
@@ -64,7 +67,7 @@ class ProcessTransaction
             );
         }
 
-        if (isset($molliePayment->_links->refunds) ? true : false) {
+        if ($molliePayment->hasRefunds()) {
             return $this->paymentProcessors->process(
                 'refunded',
                 $magentoOrder,
@@ -74,7 +77,7 @@ class ProcessTransaction
             );
         }
 
-        if (in_array($status, ['paid', 'authorized'])) {
+        if ($isPaid) {
             return $response;
         }
 

--- a/Model/Client/Payments/Processors/SuccessfulPayment.php
+++ b/Model/Client/Payments/Processors/SuccessfulPayment.php
@@ -23,6 +23,7 @@ use Mollie\Payment\Model\Client\ProcessTransactionResponse;
 use Mollie\Payment\Model\Client\ProcessTransactionResponseFactory;
 use Mollie\Payment\Service\Mollie\Order\CanRegisterCaptureNotification;
 use Mollie\Payment\Service\Mollie\Order\CanUseManualCapture;
+use Mollie\Payment\Service\Mollie\Order\IsPaymentAlreadyProcessed;
 use Mollie\Payment\Service\Order\OrderAmount;
 use Mollie\Payment\Service\Order\OrderStatePromotion;
 use Mollie\Payment\Service\Order\OrderCommentHistory;
@@ -45,6 +46,7 @@ class SuccessfulPayment implements PaymentProcessorInterface
         private readonly CanRegisterCaptureNotification $canRegisterCaptureNotification,
         private readonly CanUseManualCapture $canUseManualCapture,
         private readonly OrderStatePromotion $orderStatePromotion,
+        private readonly IsPaymentAlreadyProcessed $isPaymentAlreadyProcessed,
     ) {
     }
 
@@ -86,7 +88,7 @@ class SuccessfulPayment implements PaymentProcessorInterface
 
         /** @var PaymentInterface|Order\Payment $payment */
         $payment = $magentoOrder->getPayment();
-        if ($payment->getIsTransactionClosed() || $type != 'webhook') {
+        if ($this->isPaymentAlreadyProcessed->execute($magentoOrder) || $type != 'webhook') {
             return $this->processTransactionResponseFactory->create([
                 'success' => true,
                 'status' => 'paid',
@@ -130,6 +132,10 @@ class SuccessfulPayment implements PaymentProcessorInterface
         // Don't close the transaction if the payment method is using manual capture.
         $usesManualCapture = $this->canUseManualCapture->execute($magentoOrder);
         $payment->setIsTransactionClosed(!$usesManualCapture);
+
+        if (!$usesManualCapture) {
+            $payment->setAdditionalInformation(IsPaymentAlreadyProcessed::PAYMENT_PROCESSED, true);
+        }
 
         if ($this->canRegisterCaptureNotification->execute($magentoOrder, $molliePayment) &&
             $type != Payments::TRANSACTION_TYPE_SUBSCRIPTION &&
@@ -190,12 +196,12 @@ class SuccessfulPayment implements PaymentProcessorInterface
         $payment = $order->getPayment();
 
         /** @var null|int $statusUpdated */
-        $statusUpdated = $payment->getAdditionalInformation('mollie_status_updated');
+        $statusUpdated = $payment->getAdditionalInformation(IsPaymentAlreadyProcessed::STATUS_UPDATED);
         if ($statusUpdated === 1 && !$this->orderStatePromotion->canBePromotedToProcessing($order->getState())) {
             return;
         }
 
-        $payment->setAdditionalInformation('mollie_status_updated', 1);
+        $payment->setAdditionalInformation(IsPaymentAlreadyProcessed::STATUS_UPDATED, 1);
         $order->setState(Order::STATE_PROCESSING);
 
         if ($order->getIsVirtual()) {

--- a/Service/Mollie/Order/IsPaymentAlreadyProcessed.php
+++ b/Service/Mollie/Order/IsPaymentAlreadyProcessed.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Mollie\Order;
+
+use Magento\Sales\Api\Data\OrderInterface;
+
+class IsPaymentAlreadyProcessed
+{
+    public const PAYMENT_PROCESSED = 'mollie_payment_processed';
+    public const STATUS_UPDATED = 'mollie_status_updated';
+
+    public function __construct(
+        private readonly CanUseManualCapture $canUseManualCapture,
+    ) {}
+
+    public function execute(OrderInterface $order): bool
+    {
+        if ($this->canUseManualCapture->execute($order)) {
+            return false;
+        }
+
+        $payment = $order->getPayment();
+
+        if ($payment->getIsTransactionClosed()) {
+            return true;
+        }
+
+        if ($payment->getAdditionalInformation(self::PAYMENT_PROCESSED) === true) {
+            return true;
+        }
+
+        return $this->wasProcessedBeforeThisFlagExisted($order);
+    }
+
+    private function wasProcessedBeforeThisFlagExisted(OrderInterface $order): bool
+    {
+        return $order->getPayment()->getAdditionalInformation(self::STATUS_UPDATED) === 1
+            && $order->getInvoiceCollection()->count() > 0;
+    }
+}

--- a/Test/Integration/Model/Client/Payments/Processors/SuccessfulPaymentTest.php
+++ b/Test/Integration/Model/Client/Payments/Processors/SuccessfulPaymentTest.php
@@ -13,6 +13,7 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Mollie\Payment\Model\Client\Payments\Processors\SuccessfulPayment;
 use Mollie\Payment\Model\Client\ProcessTransactionResponse;
+use Mollie\Payment\Service\Mollie\Order\IsPaymentAlreadyProcessed;
 use Mollie\Payment\Test\Integration\IntegrationTestCase;
 use Mollie\Payment\Test\Integration\MolliePaymentBuilder;
 
@@ -74,5 +75,80 @@ class SuccessfulPaymentTest extends IntegrationTestCase
             'We expect the order status to be "processing" or "complete". Instead we got %s',
             $freshOrder->getState(),
         ));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/invoice.php
+     */
+    public function testItMarksThePaymentAsProcessed(): void
+    {
+        $order = $this->prepareOrder();
+
+        $this->processWebhook($order);
+
+        $processedOrder = $this->loadOrder('100000001');
+
+        $this->assertTrue(
+            $processedOrder->getPayment()->getAdditionalInformation(IsPaymentAlreadyProcessed::PAYMENT_PROCESSED),
+        );
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/invoice.php
+     */
+    public function testItIgnoresTheWebhookThatMollieSendsWhenTheRefundSettles(): void
+    {
+        $this->processWebhook($this->prepareOrder());
+
+        $refundedOrder = $this->loadOrder('100000001');
+        $refundedOrder->setState(Order::STATE_CLOSED);
+        $refundedOrder->setStatus(Order::STATE_CLOSED);
+        $this->removeTheStatusFlagThatOlderOrdersDoNotHave($refundedOrder);
+        $this->objectManager->get(OrderRepositoryInterface::class)->save($refundedOrder);
+
+        $this->processWebhook($this->loadOrder('100000001'));
+
+        $freshOrder = $this->loadOrder('100000001');
+
+        $this->assertEquals(Order::STATE_CLOSED, $freshOrder->getState());
+        $this->assertEquals(Order::STATE_CLOSED, $freshOrder->getStatus());
+    }
+
+    private function removeTheStatusFlagThatOlderOrdersDoNotHave(OrderInterface $order): void
+    {
+        $order->getPayment()->unsAdditionalInformation(IsPaymentAlreadyProcessed::STATUS_UPDATED);
+    }
+
+    private function prepareOrder(): OrderInterface
+    {
+        $order = $this->loadOrder('100000001');
+        $order->setMollieTransactionId('tr_ImaFDdVSCr');
+
+        $this->objectManager->get(OrderRepositoryInterface::class)->save($order);
+
+        return $this->loadOrder('100000001');
+    }
+
+    private function processWebhook(OrderInterface $order): void
+    {
+        /** @var MolliePaymentBuilder $paymentBuilder */
+        $paymentBuilder = $this->objectManager->create(MolliePaymentBuilder::class);
+        $paymentBuilder->setAmount((float)$order->getBaseGrandTotal(), $order->getBaseCurrencyCode());
+        $paymentBuilder->setStatus('paid');
+        $paymentBuilder->setMethod('ideal');
+
+        /** @var SuccessfulPayment $instance */
+        $instance = $this->objectManager->create(SuccessfulPayment::class);
+        $instance->process(
+            $order,
+            $paymentBuilder->build(),
+            'webhook',
+            $this->objectManager->create(ProcessTransactionResponse::class, [
+                'success' => true,
+                'status' => 'paid',
+                'order_id' => $order->getIncrementId(),
+                'type' => 'webhook',
+            ]),
+        );
     }
 }

--- a/Test/Integration/Service/Mollie/Order/IsPaymentAlreadyProcessedTest.php
+++ b/Test/Integration/Service/Mollie/Order/IsPaymentAlreadyProcessedTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Mollie\Order;
+
+use Mollie\Payment\Service\Mollie\Order\CanUseManualCapture;
+use Mollie\Payment\Service\Mollie\Order\IsPaymentAlreadyProcessed;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class IsPaymentAlreadyProcessedTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testItReturnsFalseWhenThePaymentWasNeverProcessed(): void
+    {
+        $order = $this->loadOrder('100000001');
+
+        $this->assertFalse($this->createInstance()->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testItReturnsTrueWhenTheProcessedFlagIsSet(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setAdditionalInformation(IsPaymentAlreadyProcessed::PAYMENT_PROCESSED, true);
+
+        $this->assertTrue($this->createInstance()->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testItReturnsTrueWhenTheTransactionIsClosedWithinTheSameRequest(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setIsTransactionClosed(true);
+
+        $this->assertTrue($this->createInstance()->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/invoice.php
+     */
+    public function testItReturnsTrueForOrdersProcessedBeforeThisFlagExisted(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setAdditionalInformation(IsPaymentAlreadyProcessed::STATUS_UPDATED, 1);
+
+        $this->assertGreaterThan(0, $order->getInvoiceCollection()->count());
+        $this->assertTrue($this->createInstance()->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testItReturnsFalseForLegacyOrdersWithoutAnInvoice(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setAdditionalInformation(IsPaymentAlreadyProcessed::STATUS_UPDATED, 1);
+
+        $this->assertFalse($this->createInstance()->execute($order));
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testItReturnsFalseWhenTheMethodUsesManualCapture(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $order->getPayment()->setAdditionalInformation(IsPaymentAlreadyProcessed::PAYMENT_PROCESSED, true);
+
+        $this->assertFalse($this->createInstance(true)->execute($order));
+    }
+
+    private function createInstance(bool $usesManualCapture = false): IsPaymentAlreadyProcessed
+    {
+        $canUseManualCapture = $this->createMock(CanUseManualCapture::class);
+        $canUseManualCapture->method('execute')->willReturn($usesManualCapture);
+
+        return $this->objectManager->create(IsPaymentAlreadyProcessed::class, [
+            'canUseManualCapture' => $canUseManualCapture,
+        ]);
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...