### PR TITLE
PIMAG-1019 | Bugfix: Send the required description key on payment fee and store credit order lines #1061

### DIFF
--- a/.github/workflows/templates/magento/configure-mollie.sh
+++ b/.github/workflows/templates/magento/configure-mollie.sh
@@ -58,6 +58,12 @@ bin/magento config:set payment/mollie_methods_wero/active 1
 # Disable queues as we don't have those in the test environment
 bin/magento config:set payment/mollie_general/process_transactions_in_the_queue 0
 
+# Enable a payment fee for Klarna so every Klarna test covers the surcharge order line (mollie/magento2#1061).
+# Tax class 2 = Taxable Goods; the fee only gets tax when a tax rule matches the shipping address.
+bin/magento config:set payment/mollie_methods_klarna/payment_surcharge_type fixed_fee
+bin/magento config:set payment/mollie_methods_klarna/payment_surcharge_fixed_amount 1.95
+bin/magento config:set payment/mollie_methods_klarna/payment_surcharge_tax_class 2
+
 # Enable Express Components. Not part of the list above because it is not controlled by the Methods API and
 # is hidden in the admin until it is active, so it can only be enabled here.
 bin/magento config:set payment/mollie_methods_expresscomponents/active 1

--- a/Service/Order/Lines/Generator/FoomanTotals.php
+++ b/Service/Order/Lines/Generator/FoomanTotals.php
@@ -44,8 +44,8 @@ class FoomanTotals implements GeneratorInterface
         $currency = $forceBaseCurrency ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
 
         foreach ($totals as $total) {
-            $amount = $forceBaseCurrency ? $total->getBaseAmount() : $total->getAmount();
-            $taxAmount = $forceBaseCurrency ? $total->getBaseTaxAmount() : $total->getTaxAmount();
+            $amount = (float)($forceBaseCurrency ? $total->getBaseAmount() : $total->getAmount());
+            $taxAmount = (float)($forceBaseCurrency ? $total->getBaseTaxAmount() : $total->getTaxAmount());
 
             $vatRate = 0;
             if ($taxAmount && $amount != 0) {

--- a/Service/Order/Lines/Generator/MagentoGiftCard.php
+++ b/Service/Order/Lines/Generator/MagentoGiftCard.php
@@ -39,7 +39,7 @@ class MagentoGiftCard implements GeneratorInterface
             'unitPrice' => $this->mollieHelper->getAmountArray($currency, -$amount),
             'totalAmount' => $this->mollieHelper->getAmountArray($currency, -$amount),
             'vatRate' => '0.00',
-            'vatAmount' => $this->mollieHelper->getAmountArray($currency, '0.00'),
+            'vatAmount' => $this->mollieHelper->getAmountArray($currency, 0.0),
         ];
 
         return $orderLines;

--- a/Service/Order/Lines/Generator/MagentoGiftWrapping.php
+++ b/Service/Order/Lines/Generator/MagentoGiftWrapping.php
@@ -43,10 +43,10 @@ class MagentoGiftWrapping implements GeneratorInterface
             'type' => OrderLineType::SURCHARGE,
             'description' => __('Magento Gift Wrapping'),
             'quantity' => 1,
-            'unitPrice' => $this->mollieHelper->getAmountArray($currency, $amount),
-            'totalAmount' => $this->mollieHelper->getAmountArray($currency, $amount),
+            'unitPrice' => $this->mollieHelper->getAmountArray($currency, (float)$amount),
+            'totalAmount' => $this->mollieHelper->getAmountArray($currency, (float)$amount),
             'vatRate' => '0.00',
-            'vatAmount' => $this->mollieHelper->getAmountArray($currency, '0.00'),
+            'vatAmount' => $this->mollieHelper->getAmountArray($currency, 0.0),
         ];
 
         return $orderLines;

--- a/Service/Order/Lines/Generator/ShippingDiscount.php
+++ b/Service/Order/Lines/Generator/ShippingDiscount.php
@@ -39,7 +39,7 @@ class ShippingDiscount implements GeneratorInterface
             'unitPrice' => $this->mollieHelper->getAmountArray($currency, -$amount),
             'totalAmount' => $this->mollieHelper->getAmountArray($currency, -$amount),
             'vatRate' => '0.00',
-            'vatAmount' => $this->mollieHelper->getAmountArray($currency, '0.00'),
+            'vatAmount' => $this->mollieHelper->getAmountArray($currency, 0.0),
         ];
 
         return $orderLines;

--- a/Service/Order/Lines/PaymentFee.php
+++ b/Service/Order/Lines/PaymentFee.php
@@ -40,8 +40,8 @@ class PaymentFee
     public function getOrderLine(OrderInterface $order, $forceBaseCurrency): array
     {
         $currency = $forceBaseCurrency ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
-        $amount = $order->getData('base_mollie_payment_fee');
-        $taxAmount = $order->getData('base_mollie_payment_fee_tax');
+        $amount = (float)$order->getData('base_mollie_payment_fee');
+        $taxAmount = (float)$order->getData('base_mollie_payment_fee_tax');
 
         $vatRate = 0;
         if ($taxAmount) {

--- a/Service/Order/Lines/PaymentFee.php
+++ b/Service/Order/Lines/PaymentFee.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mollie\Payment\Service\Order\Lines;
 
 use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Api\Types\OrderLineType;
 use Mollie\Payment\Helper\General;
 
 class PaymentFee
@@ -49,8 +50,8 @@ class PaymentFee
         }
 
         $orderLine = [
-            'type' => 'surcharge',
-            'name' => __('Payment Fee'),
+            'type' => OrderLineType::SURCHARGE,
+            'description' => __('Payment Fee'),
             'quantity' => 1,
             'unitPrice' => $this->mollieHelper->getAmountArray($currency, $amount + $taxAmount),
             'totalAmount' => $this->mollieHelper->getAmountArray($currency, $amount + $taxAmount),

--- a/Service/Order/Lines/StoreCredit.php
+++ b/Service/Order/Lines/StoreCredit.php
@@ -10,6 +10,7 @@ namespace Mollie\Payment\Service\Order\Lines;
 
 use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Api\Types\OrderLineType;
 use Mollie\Payment\Exceptions\NoStoreCreditFound;
 use Mollie\Payment\Helper\General;
 
@@ -65,8 +66,8 @@ class StoreCredit
         $vatAmount = $this->getVatAmount();
 
         $orderLine = [
-            'type' => 'store_credit',
-            'name' => __('Store Credit'),
+            'type' => OrderLineType::STORE_CREDIT,
+            'description' => __('Store Credit'),
             'quantity' => 1,
             'unitPrice' => $this->mollieHelper->getAmountArray($currency, -$unitPrice),
             'totalAmount' => $this->mollieHelper->getAmountArray($currency, -$unitPrice),

--- a/Test/Integration/Service/Order/Lines/Generator/MagentoGiftCardTest.php
+++ b/Test/Integration/Service/Order/Lines/Generator/MagentoGiftCardTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Order\Lines\Generator;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Service\Order\Lines\Generator\MagentoGiftCard;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class MagentoGiftCardTest extends IntegrationTestCase
+{
+    public function testDoesNothingWhenThereIsNoGiftCardAmount(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+
+        /** @var MagentoGiftCard $instance */
+        $instance = $this->objectManager->create(MagentoGiftCard::class);
+
+        $this->assertCount(0, $instance->process($order, []));
+    }
+
+    public function testBuildsAGiftCardLineFromStringValuesFromTheDatabase(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setBaseCurrencyCode('EUR');
+        $order->setOrderCurrencyCode('EUR');
+        $order->setData('gift_cards_amount', '10.0000');
+        $order->setData('base_gift_cards_amount', '10.0000');
+
+        /** @var MagentoGiftCard $instance */
+        $instance = $this->objectManager->create(MagentoGiftCard::class);
+
+        $result = $instance->process($order, []);
+
+        $this->assertCount(1, $result);
+        $line = end($result);
+        $this->assertEquals('-10.00', $line['unitPrice']['value']);
+        $this->assertEquals('-10.00', $line['totalAmount']['value']);
+        $this->assertEquals('0.00', $line['vatAmount']['value']);
+    }
+}

--- a/Test/Integration/Service/Order/Lines/Generator/ShippingDiscountTest.php
+++ b/Test/Integration/Service/Order/Lines/Generator/ShippingDiscountTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Order\Lines\Generator;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Mollie\Payment\Service\Order\Lines\Generator\ShippingDiscount;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class ShippingDiscountTest extends IntegrationTestCase
+{
+    public function testDoesNothingWhenThereIsNoShippingDiscount(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+
+        /** @var ShippingDiscount $instance */
+        $instance = $this->objectManager->create(ShippingDiscount::class);
+
+        $this->assertCount(0, $instance->process($order, []));
+    }
+
+    public function testBuildsADiscountLineFromStringValuesFromTheDatabase(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setBaseCurrencyCode('EUR');
+        $order->setOrderCurrencyCode('EUR');
+        $order->setData('shipping_discount_amount', '5.0000');
+        $order->setData('base_shipping_discount_amount', '5.0000');
+
+        /** @var ShippingDiscount $instance */
+        $instance = $this->objectManager->create(ShippingDiscount::class);
+
+        $result = $instance->process($order, []);
+
+        $this->assertCount(1, $result);
+        $line = end($result);
+        $this->assertEquals('-5.00', $line['unitPrice']['value']);
+        $this->assertEquals('-5.00', $line['totalAmount']['value']);
+        $this->assertEquals('0.00', $line['vatAmount']['value']);
+    }
+}

--- a/Test/Integration/Service/Order/Lines/PaymentFeeTest.php
+++ b/Test/Integration/Service/Order/Lines/PaymentFeeTest.php
@@ -42,4 +42,24 @@ class PaymentFeeTest extends IntegrationTestCase
 
         $line = $instance->getOrderLine($order, true);
     }
+
+    public function testGetOrderLineAcceptsStringValuesFromTheDatabase(): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setBaseCurrencyCode('EUR');
+
+        $order->setData('base_mollie_payment_fee', '1.6500');
+        $order->setData('base_mollie_payment_fee_tax', '0.3500');
+
+        /** @var PaymentFee $instance */
+        $instance = $this->objectManager->create(PaymentFee::class);
+
+        $line = $instance->getOrderLine($order, true);
+
+        $this->assertEquals('2.00', $line['unitPrice']['value']);
+        $this->assertEquals('2.00', $line['totalAmount']['value']);
+        $this->assertEquals('0.35', $line['vatAmount']['value']);
+        $this->assertEquals(21.21, $line['vatRate']);
+    }
 }

--- a/Test/Integration/Service/Order/Lines/PaymentFeeTest.php
+++ b/Test/Integration/Service/Order/Lines/PaymentFeeTest.php
@@ -41,6 +41,10 @@ class PaymentFeeTest extends IntegrationTestCase
         $instance = $this->objectManager->create(PaymentFee::class);
 
         $line = $instance->getOrderLine($order, true);
+
+        $this->assertEquals('surcharge', $line['type']);
+        $this->assertEquals(__('Payment Fee'), $line['description']);
+        $this->assertArrayNotHasKey('name', $line);
     }
 
     public function testGetOrderLineAcceptsStringValuesFromTheDatabase(): void

--- a/Test/Integration/Service/Order/Lines/StoreCreditTest.php
+++ b/Test/Integration/Service/Order/Lines/StoreCreditTest.php
@@ -140,7 +140,8 @@ class StoreCreditTest extends IntegrationTestCase
         $result = $instance->getOrderLine($order, true);
 
         $this->assertEquals('store_credit', $result['type']);
-        $this->assertEquals(__('Store Credit'), $result['name']);
+        $this->assertEquals(__('Store Credit'), $result['description']);
+        $this->assertArrayNotHasKey('name', $result);
         $this->assertEquals(1, $result['quantity']);
         $this->assertEquals(['currency' => 'EUR', 'value' => '-20.00'], $result['unitPrice']);
         $this->assertEquals(['currency' => 'EUR', 'value' => '-20.00'], $result['totalAmount']);


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...