### PR TITLE
PIMAG-1021 | Bugfix: Allow online refunds for orders placed through the V2 Orders API

### DIFF
--- a/Model/Methods/Reorder.php
+++ b/Model/Methods/Reorder.php
@@ -29,6 +29,7 @@ use Mollie\Payment\Model\Client\Payments as PaymentsApi;
 use Mollie\Payment\Model\Client\Payments\ProcessTransaction as PaymentsProcessTransaction;
 use Mollie\Payment\Model\Mollie;
 use Mollie\Payment\Service\Mollie\MollieApiClient;
+use Mollie\Payment\Service\Mollie\Order\ResolvePaymentId;
 use Mollie\Payment\Service\OrderLockService;
 use Psr\Log\LoggerInterface;
 
@@ -59,6 +60,7 @@ class Reorder extends Mollie
         PaymentsProcessTransaction $paymentsProcessTransaction,
         OrderLockService $orderLockService,
         MollieApiClient $mollieApiClient,
+        ResolvePaymentId $resolvePaymentId,
         private RequestInterface $request,
         $formBlockType,
         $infoBlockType,
@@ -80,6 +82,7 @@ class Reorder extends Mollie
             $paymentsProcessTransaction,
             $orderLockService,
             $mollieApiClient,
+            $resolvePaymentId,
             $formBlockType,
             $infoBlockType,
             $commandPool,

--- a/Model/Methods/Voucher.php
+++ b/Model/Methods/Voucher.php
@@ -25,6 +25,7 @@ use Mollie\Payment\Model\Client\Payments as PaymentsApi;
 use Mollie\Payment\Model\Client\Payments\ProcessTransaction as PaymentsProcessTransaction;
 use Mollie\Payment\Model\Mollie;
 use Mollie\Payment\Service\Mollie\MollieApiClient;
+use Mollie\Payment\Service\Mollie\Order\ResolvePaymentId;
 use Mollie\Payment\Service\OrderLockService;
 use Mollie\Payment\Service\Quote\QuoteHasMealVoucherProducts;
 use Psr\Log\LoggerInterface;
@@ -51,6 +52,7 @@ class Voucher extends Mollie
         PaymentsProcessTransaction $paymentsProcessTransaction,
         OrderLockService $orderLockService,
         MollieApiClient $mollieApiClient,
+        ResolvePaymentId $resolvePaymentId,
         $formBlockType,
         $infoBlockType,
         private QuoteHasMealVoucherProducts $quoteHasMealVoucherProducts,
@@ -72,6 +74,7 @@ class Voucher extends Mollie
             $paymentsProcessTransaction,
             $orderLockService,
             $mollieApiClient,
+            $resolvePaymentId,
             $formBlockType,
             $infoBlockType,
             $commandPool,

--- a/Model/Mollie.php
+++ b/Model/Mollie.php
@@ -34,6 +34,7 @@ use Mollie\Payment\Helper\General;
 use Mollie\Payment\Model\Client\Payments;
 use Mollie\Payment\Model\Client\Payments\ProcessTransaction;
 use Mollie\Payment\Model\Client\ProcessTransactionResponse;
+use Mollie\Payment\Service\Mollie\Order\ResolvePaymentId;
 use Mollie\Payment\Service\OrderLockService;
 use Psr\Log\LoggerInterface;
 
@@ -60,6 +61,7 @@ class Mollie extends Adapter
         private ProcessTransaction $paymentsProcessTransaction,
         private OrderLockService $orderLockService,
         private \Mollie\Payment\Service\Mollie\MollieApiClient $mollieApiClient,
+        private ResolvePaymentId $resolvePaymentId,
         $formBlockType,
         $infoBlockType,
         ?CommandPoolInterface $commandPool = null,
@@ -361,12 +363,6 @@ class Mollie extends Adapter
         $order = $payment->getOrder();
         $storeId = storeId($order->getStoreId());
 
-        if ($this->mollieHelper->getCheckoutType($order) == 'order') {
-            throw new LocalizedException(
-                __('This order was placed using the Mollie Orders API, which is no longer supported in v3. Please process this refund via the Mollie Dashboard.')
-            );
-        }
-
         $transactionId = $order->getMollieTransactionId();
         if (empty($transactionId)) {
             throw new LocalizedException(__('Transaction ID not found'));
@@ -389,6 +385,7 @@ class Mollie extends Adapter
             }
 
             $mollieApi = $this->loadMollieApi($apiKey);
+            $transactionId = $this->resolvePaymentId->execute($mollieApi, $transactionId);
             $payment = $mollieApi->payments->get($transactionId);
 
             // @see https://github.com/mollie/mollie-api-php/issues/840

--- a/Test/Integration/Model/MollieTest.php
+++ b/Test/Integration/Model/MollieTest.php
@@ -19,6 +19,7 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 use Mollie\Api\Fake\MockResponse;
 use Mollie\Api\Http\Requests\CreatePaymentRefundRequest;
 use Mollie\Api\Http\Requests\CreatePaymentRequest;
+use Mollie\Api\Http\Requests\DynamicGetRequest;
 use Mollie\Api\Http\Requests\GetPaymentRequest;
 use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
@@ -261,6 +262,124 @@ class MollieTest extends IntegrationTestCase
         $infoPayment->setCreditmemo($creditmemo);
 
         $instance->refund($infoPayment, 12.34);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_general/currency 0
+     * @magentoConfigFixture default_store payment/mollie_general/type test
+     * @magentoConfigFixture default_store payment/mollie_general/apikey_test test_dummyapikeywhichmustbe30characterslong
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testRefundsALegacyOrdersApiOrderViaItsPaymentId(): void
+    {
+        if (getenv('CI')) {
+            $this->markTestSkipped('Fails on CI');
+        }
+
+        $order = $this->loadOrder('100000001');
+        $order->setMollieTransactionId('ord_legacy123');
+
+        $client = MollieApiClient::fake([
+            DynamicGetRequest::class => MockResponse::ok($this->legacyOrderWithPaymentsResponse()),
+            GetPaymentRequest::class => MockResponse::ok('payment'),
+            CreatePaymentRefundRequest::class => MockResponse::ok('refund'),
+        ]);
+
+        $mollieApiMock = $this->objectManager->create(FakeMollieApiClient::class);
+        $mollieApiMock->setInstance($client);
+
+        $this->objectManager->addSharedInstance($mollieApiMock, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        /** @var Mollie $instance */
+        $instance = $this->objectManager->create(Mollie::class);
+
+        /** @var \Magento\Sales\Model\Order\Payment $infoPayment */
+        $infoPayment = $this->objectManager->get(\Magento\Sales\Model\Order\Payment::class);
+        $infoPayment->setOrder($order);
+        $infoPayment->setAdditionalInformation('checkout_type', 'order');
+
+        $creditmemo = $this->objectManager->create(CreditmemoInterface::class);
+        $creditmemo->setBaseGrandTotal(12.34);
+        $creditmemo->setGrandTotal(56.78);
+        $infoPayment->setCreditmemo($creditmemo);
+
+        $instance->refund($infoPayment, 12.34);
+
+        $this->assertNotEmpty($order->getPayment()->getLastTransId());
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     * @magentoConfigFixture default_store payment/mollie_general/currency 0
+     * @magentoConfigFixture default_store payment/mollie_general/type test
+     * @magentoConfigFixture default_store payment/mollie_general/apikey_test test_dummyapikeywhichmustbe30characterslong
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    public function testRefundsALegacyOrdersApiOrderPartially(): void
+    {
+        if (getenv('CI')) {
+            $this->markTestSkipped('Fails on CI');
+        }
+
+        $order = $this->loadOrder('100000001');
+        $order->setMollieTransactionId('ord_legacy123');
+
+        $client = MollieApiClient::fake([
+            DynamicGetRequest::class => MockResponse::ok($this->legacyOrderWithPaymentsResponse()),
+            GetPaymentRequest::class => MockResponse::ok('payment'),
+            CreatePaymentRefundRequest::class => MockResponse::ok('refund'),
+        ]);
+
+        $mollieApiMock = $this->objectManager->create(FakeMollieApiClient::class);
+        $mollieApiMock->setInstance($client);
+
+        $this->objectManager->addSharedInstance($mollieApiMock, \Mollie\Payment\Service\Mollie\MollieApiClient::class);
+
+        /** @var Mollie $instance */
+        $instance = $this->objectManager->create(Mollie::class);
+
+        /** @var \Magento\Sales\Model\Order\Payment $infoPayment */
+        $infoPayment = $this->objectManager->get(\Magento\Sales\Model\Order\Payment::class);
+        $infoPayment->setOrder($order);
+        $infoPayment->setAdditionalInformation('checkout_type', 'order');
+
+        $creditmemo = $this->objectManager->create(CreditmemoInterface::class);
+        $creditmemo->setBaseGrandTotal(25.00);
+        $creditmemo->setGrandTotal(25.00);
+        $infoPayment->setCreditmemo($creditmemo);
+
+        $instance->refund($infoPayment, 25.00);
+
+        $client->assertSent(function ($pendingRequest): bool {
+            if (!$pendingRequest->getRequest() instanceof CreatePaymentRefundRequest) {
+                return false;
+            }
+
+            $amount = $pendingRequest->payload()->get('amount');
+            $value = is_array($amount) ? $amount['value'] : $amount->value;
+
+            $this->assertEquals('25.00', $value);
+
+            return true;
+        });
+    }
+
+    private function legacyOrderWithPaymentsResponse(): string
+    {
+        return '{
+            "resource": "order",
+            "id": "ord_legacy123",
+            "_embedded": {
+                "payments": [
+                    {"resource": "payment", "id": "tr_paid456", "status": "paid"}
+                ]
+            }
+        }';
     }
 
     /**

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -456,7 +456,8 @@
                 <allowspecific>0</allowspecific>
                 <can_use_checkout>0</can_use_checkout>
                 <can_order>0</can_order>
-                <can_refund>0</can_refund>
+                <can_refund>1</can_refund>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
                 <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnapaylater>
@@ -468,7 +469,8 @@
                 <allowspecific>0</allowspecific>
                 <can_use_checkout>0</can_use_checkout>
                 <can_order>0</can_order>
-                <can_refund>0</can_refund>
+                <can_refund>1</can_refund>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
                 <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnapaynow>
@@ -480,7 +482,8 @@
                 <allowspecific>0</allowspecific>
                 <can_use_checkout>0</can_use_checkout>
                 <can_order>0</can_order>
-                <can_refund>0</can_refund>
+                <can_refund>1</can_refund>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_use_internal>0</can_use_internal>
                 <supports_partial_capture>1</supports_partial_capture>
             </mollie_methods_klarnasliceit>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...