### PR TITLE
PIMAG-1020 | Bugfix: TypeError when saving payment method config at store view scope #1064

### DIFF
--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -41,10 +41,7 @@ class ConfigObserver implements ObserverInterface
      */
     public function execute(EventObserver $observer): void
     {
-        $storeId = $observer->getStore();
-        if ($storeId === null || $storeId === '') {
-            $storeId = 0;
-        }
+        $storeId = storeId($observer->getStore());
 
         $enabled = $this->mollieHelper->isAvailable($storeId);
         $modus = $this->mollieHelper->getModus($storeId);

--- a/Test/End-2-end/tests/backend/save-config-storeview.spec.ts
+++ b/Test/End-2-end/tests/backend/save-config-storeview.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import {expect, test, type Page} from '@playwright/test';
+
+const storeViewId = 1;
+const idealGroup = 'mollie_payment_methods_mollie_methods_ideal';
+
+test('Can save a payment method value at store view scope', async ({page}) => {
+    await openPaymentMethodsSectionAtStoreViewScope(page);
+
+    const dialog = await openMethodDialog(page);
+
+    const inherit = dialog.locator(`#${idealGroup}_title_inherit`);
+    if (await inherit.isChecked()) {
+        await inherit.uncheck();
+    }
+
+    await dialog.locator(`#${idealGroup}_title`).fill('iDEAL store view title');
+    await saveAndExpectSuccess(page, dialog);
+
+    const dialogAfterSave = await openMethodDialog(page);
+    await expect(dialogAfterSave.locator(`#${idealGroup}_title`)).toHaveValue('iDEAL store view title');
+
+    // Restore the inherited value so this test has no side effects on other tests
+    await dialogAfterSave.locator(`#${idealGroup}_title_inherit`).check();
+    await saveAndExpectSuccess(page, dialogAfterSave);
+});
+
+async function openPaymentMethodsSectionAtStoreViewScope(page: Page): Promise<void> {
+    await page.goto('/admin/');
+
+    const configLink = page.locator('[data-ui-id="menu-magento-config-system-config"] > a');
+    const href = await configLink.getAttribute('href');
+    await page.goto(href);
+
+    await page.locator('.config-nav-block._show').waitFor({state: 'visible', timeout: 30000});
+    await page.locator('.mollie-tab').click();
+    await page.locator('.mollie-tab._show').waitFor({state: 'visible', timeout: 30000});
+    await page.locator('.mollie-tab._show a', {hasText: 'Payment Methods'}).click();
+
+    await page.waitForURL(/admin\/system_config\/edit\/section\/mollie_payment_methods/);
+
+    await page.goto(page.url().replace(/\/?$/, '/') + `store/${storeViewId}/`);
+}
+
+async function openMethodDialog(page: Page) {
+    const cardHead = page.locator(`#${idealGroup}-head`);
+    await cardHead.waitFor({state: 'visible', timeout: 60000});
+    await cardHead.click();
+
+    const dialog = page.locator(`#${idealGroup}_dialog`);
+    await expect(dialog).toBeVisible();
+
+    return dialog;
+}
+
+async function saveAndExpectSuccess(page: Page, dialog: ReturnType<Page['locator']>): Promise<void> {
+    await dialog.locator('.mollie-payment-save-config').click();
+
+    await expect(page.getByText('You saved the configuration.')).toBeVisible();
+    expect(page.url()).toContain(`/store/${storeViewId}/`);
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...