### PR TITLE
PIMAG-1026 | Bugfix: Delete a guest payment reminder when the same shopper orders while logged in

### DIFF
--- a/Observer/SalesOrderPlaceBefore/RemovePendingPaymentReminders.php
+++ b/Observer/SalesOrderPlaceBefore/RemovePendingPaymentReminders.php
@@ -39,8 +39,12 @@ class RemovePendingPaymentReminders implements ObserverInterface
 
         if ($customerId = $order->getCustomerId()) {
             $this->deletePaymentReminder->deleteByCustomerId((int)$customerId);
-            return;
         }
-        $this->deletePaymentReminder->deleteByEmail((string)$order->getCustomerEmail());
+
+        // Also delete by email, even when the order has a customer id. A reminder queued during an
+        // earlier guest attempt is stored with customer_id NULL and a hashed email, so deleteByCustomerId
+        // can never match it. Without this the shopper receives the second chance email for the guest
+        // attempt they have just completed while logged in.
+        $this->deletePaymentReminder->deleteByEmail((string)$email);
     }
 }

--- a/Test/Integration/Observer/SalesOrderPlaceBefore/RemovePendingPaymentRemindersTest.php
+++ b/Test/Integration/Observer/SalesOrderPlaceBefore/RemovePendingPaymentRemindersTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Mollie\Payment\Test\Integration\Observer\SalesOrderPlaceBefore;
 
+use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Mollie\Payment\Api\Data\PendingPaymentReminderInterfaceFactory;
 use Mollie\Payment\Api\PendingPaymentReminderRepositoryInterface;
@@ -65,5 +67,88 @@ class RemovePendingPaymentRemindersTest extends IntegrationTestCase
         $this->objectManager->create(RemovePendingPaymentReminders::class)->execute($observer);
 
         $this->assertSame($saved->getEntityId(), $repository->get($saved->getEntityId())->getEntityId());
+    }
+
+    /**
+     * A reminder queued during a guest attempt is stored with customer_id NULL and a hashed email, so
+     * deleteByCustomerId can never match it. The shopper used to receive the second chance email for
+     * the guest attempt they had just completed while logged in.
+     *
+     * @magentoConfigFixture default_store payment/mollie_general/enable_second_chance_email 1
+     * @magentoConfigFixture default_store payment/mollie_general/automatically_send_second_chance_emails 1
+     */
+    public function testDeletesTheGuestReminderWhenTheSameShopperOrdersWhileLoggedIn(): void
+    {
+        $repository = $this->objectManager->get(PendingPaymentReminderRepositoryInterface::class);
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+
+        $reminder = $this->objectManager->get(PendingPaymentReminderInterfaceFactory::class)->create();
+        $reminder->setOrderId(99999);
+        $reminder->setHash($encryptor->hash('test@example.com'));
+        $saved = $repository->save($reminder);
+
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setCustomerId(1);
+        $order->setCustomerEmail('test@example.com');
+
+        $observer = $this->objectManager->create(Observer::class);
+        $observer->setData('order', $order);
+
+        $this->objectManager->create(RemovePendingPaymentReminders::class)->execute($observer);
+
+        $this->expectException(NoSuchEntityException::class);
+        $repository->get($saved->getEntityId());
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/enable_second_chance_email 1
+     * @magentoConfigFixture default_store payment/mollie_general/automatically_send_second_chance_emails 1
+     */
+    public function testStillDeletesTheReminderBelongingToTheOrdersOwnCustomer(): void
+    {
+        $repository = $this->objectManager->get(PendingPaymentReminderRepositoryInterface::class);
+
+        $reminder = $this->objectManager->get(PendingPaymentReminderInterfaceFactory::class)->create();
+        $reminder->setOrderId(99999);
+        $reminder->setCustomerId(1);
+        $saved = $repository->save($reminder);
+
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setCustomerId(1);
+        $order->setCustomerEmail('test@example.com');
+
+        $observer = $this->objectManager->create(Observer::class);
+        $observer->setData('order', $order);
+
+        $this->objectManager->create(RemovePendingPaymentReminders::class)->execute($observer);
+
+        $this->expectException(NoSuchEntityException::class);
+        $repository->get($saved->getEntityId());
+    }
+
+    /**
+     * @magentoConfigFixture default_store payment/mollie_general/enable_second_chance_email 1
+     * @magentoConfigFixture default_store payment/mollie_general/automatically_send_second_chance_emails 1
+     */
+    public function testDeletesTheGuestReminderForAGuestOrder(): void
+    {
+        $repository = $this->objectManager->get(PendingPaymentReminderRepositoryInterface::class);
+        $encryptor = $this->objectManager->get(EncryptorInterface::class);
+
+        $reminder = $this->objectManager->get(PendingPaymentReminderInterfaceFactory::class)->create();
+        $reminder->setOrderId(99999);
+        $reminder->setHash($encryptor->hash('test@example.com'));
+        $saved = $repository->save($reminder);
+
+        $order = $this->objectManager->create(OrderInterface::class);
+        $order->setCustomerEmail('test@example.com');
+
+        $observer = $this->objectManager->create(Observer::class);
+        $observer->setData('order', $order);
+
+        $this->objectManager->create(RemovePendingPaymentReminders::class)->execute($observer);
+
+        $this->expectException(NoSuchEntityException::class);
+        $repository->get($saved->getEntityId());
     }
 }


### PR DESCRIPTION
### Describe the bug

A shopper who abandons a bank transfer or other pending payment **as a guest**, and later completes the purchase **while logged in with the same email address**, still receives the second chance email for the attempt they have already paid for.

### Cause

`Observer\SalesOrderPlaceBefore\RemovePendingPaymentReminders::execute()` returns as soon as it has deleted by customer id:

```php
if ($customerId = $order->getCustomerId()) {
    $this->deletePaymentReminder->deleteByCustomerId((int)$customerId);
    return;
}
$this->deletePaymentReminder->deleteByEmail((string)$order->getCustomerEmail());
```

`Observer\MollieStartTransaction\SavePendingOrder` stores a guest reminder with `customer_id` NULL and a hashed email. `DeletePaymentReminder::deleteByEmail()` is the only method that matches such a row — it filters on `customer_id IS NULL` and `hash`. `deleteByCustomerId()` filters on `customer_id = ?` and therefore never matches it.

So the early `return` means a guest reminder is only ever cleared by a later **guest** order. A registered order by the same person leaves it in place, and `SendPendingPaymentReminders` sends it on the next run.

### Expected behavior

Placing an order clears every pending reminder belonging to that shopper, whether it was queued while they were a guest or while they were logged in.

### The change

Let both deletes run:

```php
if ($customerId = $order->getCustomerId()) {
    $this->deletePaymentReminder->deleteByCustomerId((int)$customerId);
}

$this->deletePaymentReminder->deleteByEmail((string)$email);
```

`deleteByEmail()` already returns early on an empty string, and `execute()` has established that `$email` is non-empty a few lines above, so the extra call is a no-op when there is nothing to match.

### Tests

Three integration tests added to the existing `Test/Integration/Observer/SalesOrderPlaceBefore/RemovePendingPaymentRemindersTest.php`, following the `@magentoConfigFixture` pattern already used there:

- `testDeletesTheGuestReminderWhenTheSameShopperOrdersWhileLoggedIn` — the regression. Fails on `master`.
- `testStillDeletesTheReminderBelongingToTheOrdersOwnCustomer` — the existing behaviour is not lost.
- `testDeletesTheGuestReminderForAGuestOrder` — the guest path is unchanged.

I was not able to run the integration suite locally, so I would appreciate CI confirming them.

### A related question, for you to decide

Issue #467 (closed, 2021) reported a different defect in the same service, and the reporter argued there:

> I do not really see why the customer ID specifically has to be null anyway. We can delete the record if the e-mailaddress matches.

Dropping the `customer_id IS NULL` filter from `deleteByEmail()` would fix this case too, and more broadly. I have deliberately **not** done that here, because it changes behaviour for registered customers as well and that is your call, not mine. Happy to rework this PR that way if you prefer it.

### Used versions

- Magento: 2.4.7-p6, Open Source
- Mollie: found on 2.49.0, fix written against `master` (3.1.3), where the code has since been refactored but the early return remains
