### PR TITLE
PIMAG-1025 | Use surcharge type for positive Geissweb EU VAT balancing line

### DIFF
--- a/Service/Order/Lines/Generator/GeisswebEuvat.php
+++ b/Service/Order/Lines/Generator/GeisswebEuvat.php
@@ -44,13 +44,14 @@ class GeisswebEuvat implements GeneratorInterface
         }
 
         $currency = $forceBaseCurrency ? $order->getBaseCurrencyCode() : $order->getOrderCurrencyCode();
+        $residual = $orderTotal - $orderLinesTotal;
 
         $orderLines[] = [
-            'type' => 'discount',
+            'type' => $residual < 0 ? 'discount' : 'surcharge',
             'description' => 'EU VAT',
             'quantity' => 1,
-            'unitPrice' => $this->mollieHelper->getAmountArray($currency, $orderTotal - $orderLinesTotal),
-            'totalAmount' => $this->mollieHelper->getAmountArray($currency, $orderTotal - $orderLinesTotal),
+            'unitPrice' => $this->mollieHelper->getAmountArray($currency, $residual),
+            'totalAmount' => $this->mollieHelper->getAmountArray($currency, $residual),
             'vatRate' => 0,
             'vatAmount' => $this->mollieHelper->getAmountArray($currency, 0),
         ];

--- a/Test/Integration/Service/Order/Lines/Generator/GeisswebEuvatTest.php
+++ b/Test/Integration/Service/Order/Lines/Generator/GeisswebEuvatTest.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Order\Lines\Generator;
+
+use Magento\Framework\Module\Manager;
+use Mollie\Payment\Service\Order\Lines\Generator\GeisswebEuvat;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class GeisswebEuvatTest extends IntegrationTestCase
+{
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testDoesNothingWhenTheModuleIsDisabled(): void
+    {
+        $order = $this->loadOrder('100000001');
+
+        $moduleManagerMock = $this->createMock(Manager::class);
+        $moduleManagerMock->method('isEnabled')->willReturn(false);
+
+        /** @var GeisswebEuvat $instance */
+        $instance = $this->objectManager->create(GeisswebEuvat::class, [
+            'moduleManager' => $moduleManagerMock,
+        ]);
+
+        $result = $instance->process($order, [$this->buildOrderLine('90.00')]);
+
+        $this->assertCount(1, $result);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testDoesNothingWhenTheResidualIsZero(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $instance = $this->createInstanceWithModuleEnabled();
+
+        $result = $instance->process($order, [$this->buildOrderLine('100.00')]);
+
+        $this->assertCount(1, $result);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testUsesSurchargeTypeWhenTheResidualIsPositive(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $instance = $this->createInstanceWithModuleEnabled();
+
+        $result = $instance->process($order, [$this->buildOrderLine('90.00')]);
+        $this->assertCount(2, $result);
+
+        $balancingLine = end($result);
+        $this->assertEquals('10.00', $balancingLine['unitPrice']['value']);
+        $this->assertEquals('surcharge', $balancingLine['type']);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Sales/_files/order.php
+     */
+    public function testUsesDiscountTypeWhenTheResidualIsNegative(): void
+    {
+        $order = $this->loadOrder('100000001');
+        $instance = $this->createInstanceWithModuleEnabled();
+
+        $result = $instance->process($order, [$this->buildOrderLine('110.00')]);
+        $this->assertCount(2, $result);
+
+        $balancingLine = end($result);
+        $this->assertEquals('-10.00', $balancingLine['unitPrice']['value']);
+        $this->assertEquals('discount', $balancingLine['type']);
+    }
+
+    private function createInstanceWithModuleEnabled(): GeisswebEuvat
+    {
+        $moduleManagerMock = $this->createMock(Manager::class);
+        $moduleManagerMock->method('isEnabled')->willReturn(true);
+
+        /** @var GeisswebEuvat $instance */
+        $instance = $this->objectManager->create(GeisswebEuvat::class, [
+            'moduleManager' => $moduleManagerMock,
+        ]);
+
+        return $instance;
+    }
+
+    private function buildOrderLine(string $totalAmount): array
+    {
+        return [
+            'type' => 'physical',
+            'description' => 'Simple Product',
+            'quantity' => 1,
+            'unitPrice' => ['currency' => 'USD', 'value' => $totalAmount],
+            'totalAmount' => ['currency' => 'USD', 'value' => $totalAmount],
+        ];
+    }
+}


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...