### PR TITLE
PIMAG-1031 | Fix PayPal Express guest email resolution

### DIFF
--- a/Service/Mollie/Order/GetCustomerFromPayment.php
+++ b/Service/Mollie/Order/GetCustomerFromPayment.php
@@ -15,7 +15,6 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Mollie\Api\Resources\Payment;
-use stdClass;
 
 class GetCustomerFromPayment
 {
@@ -29,8 +28,9 @@ class GetCustomerFromPayment
     {
         $billingAddress = $payment->billingAddress;
 
+        $email = $this->getEmail($oldCart, $payment);
+
         try {
-            $email = $this->getEmail($oldCart, $billingAddress);
             return $this->customerRepository->get($email);
         } catch (NoSuchEntityException) {
         }
@@ -50,8 +50,10 @@ class GetCustomerFromPayment
         return $this->customerRepository->save($customer);
     }
 
-    private function getEmail(CartInterface $oldCart, ?stdClass $billingAddress): string
+    private function getEmail(CartInterface $oldCart, Payment $payment): string
     {
+        $billingAddress = $payment->billingAddress;
+
         if ($oldCart->getCustomerEmail()) {
             return $oldCart->getCustomerEmail();
         }
@@ -62,10 +64,16 @@ class GetCustomerFromPayment
 
         $email = $oldCart->getPayment()->getAdditionalInformation('mollie_guest_email');
 
-        if (!$email) {
-            throw new NoSuchEntityException(__('No email address found for this payment.'));
+        if ($email) {
+            return $email;
         }
 
-        return $email;
+        $consumerAccount = $payment->details->consumerAccount ?? null;
+
+        if (is_string($consumerAccount) && filter_var($consumerAccount, FILTER_VALIDATE_EMAIL)) {
+            return $consumerAccount;
+        }
+
+        throw new NoSuchEntityException(__('No email address found for this payment.'));
     }
 }


### PR DESCRIPTION
## What changed

- resolve a PayPal Express guest email from `payment.details.consumerAccount` when it is an email address
- resolve the email before catching `CustomerRepositoryInterface::get()` misses, so a missing email cannot leave `$email` undefined
- preserve the existing cart, billing-address, and `mollie_guest_email` precedence

## Why

For PayPal Express, `billingAddress.email` can be absent even though Mollie exposes the PayPal account email as `details.consumerAccount`. In the no-email path, `getEmail()` throws `NoSuchEntityException`, but the surrounding catch currently also catches that exception and then reaches `setEmail($email)` with an uninitialized variable.

Validating `consumerAccount` as an email keeps the fallback specific: non-email account identifiers from other payment methods are ignored.

Fixes #1076.

## Verification

I traced both failure paths against the 3.1.3 implementation. This repository does not currently include a unit-test suite for this service, and PHP is unavailable in my minimal contribution environment, so I have not represented this as runtime-tested. The change is narrow and preserves the existing method return type and exception behavior when no usable email exists.