### PR TITLE
PIMAG-1027 | Bugfix: Only render Mollie's own messages in the payment method #1075

### DIFF
--- a/Controller/Checkout/Process.php
+++ b/Controller/Checkout/Process.php
@@ -21,6 +21,7 @@ use Magento\Payment\Helper\Data;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Mollie\Payment\Helper\General;
 use Mollie\Payment\Model\Mollie;
+use Mollie\Payment\Service\Checkout\PaymentMethodMessages;
 use Mollie\Payment\Service\Mollie\GetMollieStatusResult;
 use Mollie\Payment\Service\Mollie\Order\AddResultMessage;
 use Mollie\Payment\Service\Mollie\Order\SuccessPageRedirect;
@@ -43,6 +44,7 @@ class Process extends Action implements HttpGetActionInterface
         private SuccessPageRedirect $successPageRedirect,
         private AddResultMessage $addResultMessage,
         private EncryptorInterface $encryptor,
+        private PaymentMethodMessages $paymentMethodMessages,
     ) {
         parent::__construct($context);
     }
@@ -55,7 +57,7 @@ class Process extends Action implements HttpGetActionInterface
         $orderIds = $this->validateProcessRequest->execute();
         if (!$orderIds) {
             $this->mollieHelper->addTolog('error', __('Invalid return, missing order id.'));
-            $this->messageManager->addNoticeMessage(__('Invalid return from Mollie.'));
+            $this->paymentMethodMessages->addNotice(__('Invalid return from Mollie.'));
 
             return $this->_redirect($this->redirectOnError->getUrl());
         }
@@ -68,7 +70,7 @@ class Process extends Action implements HttpGetActionInterface
             }
         } catch (Exception $e) {
             $this->mollieHelper->addTolog('error', $e->getMessage());
-            $this->messageManager->addExceptionMessage($e, __('There was an error checking the transaction status.'));
+            $this->paymentMethodMessages->addException($e, __('There was an error checking the transaction status.'));
 
             return $this->_redirect($this->redirectOnError->getUrl());
         }
@@ -80,7 +82,7 @@ class Process extends Action implements HttpGetActionInterface
                 return $this->getResponse();
             } catch (Exception $e) {
                 $this->mollieHelper->addTolog('error', $e->getMessage());
-                $this->messageManager->addErrorMessage(__('Transaction failed. Please verify your billing information and payment method, and try again.'));
+                $this->paymentMethodMessages->addError(__('Transaction failed. Please verify your billing information and payment method, and try again.'));
 
                 return $this->_redirect($this->redirectOnError->getUrl());
             }

--- a/Model/MollieConfigProvider.php
+++ b/Model/MollieConfigProvider.php
@@ -22,6 +22,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Mollie\Api\Types\MethodQuery;
 use Mollie\Payment\Config;
 use Mollie\Payment\Helper\General;
+use Mollie\Payment\Service\Checkout\PaymentMethodMessages;
 use Mollie\Payment\Service\Mollie\ApplePay\SupportedNetworks;
 use Mollie\Payment\Service\Mollie\GetCustomerMandates;
 use Mollie\Payment\Service\Mollie\GetIssuers;
@@ -41,6 +42,8 @@ class MollieConfigProvider implements ConfigProviderInterface
     private array $methods = [];
     /** @var array<string, array<string, mixed>>|null */
     private ?array $methodData = null;
+    /** @var array<int, array{type: string, text: string}>|null */
+    private ?array $messages = null;
 
     public function __construct(
         private Http $request,
@@ -58,11 +61,23 @@ class MollieConfigProvider implements ConfigProviderInterface
         private GetCustomerMandates $getCustomerMandates,
         private SavedCardConsentText $savedCardConsentText,
         private CustomerSession $customerSession,
+        private PaymentMethodMessages $paymentMethodMessages,
     )
     {
         foreach (PaymentMethods::METHODS as $code) {
             $this->methods[$code] = $this->getMethodInstance($code);
         }
+    }
+
+    /**
+     * The messages are removed from the session when they are read, so they are kept around in case the checkout
+     * config is built more than once during the same request.
+     *
+     * @return array<int, array{type: string, text: string}>
+     */
+    private function getMessages(): array
+    {
+        return $this->messages ??= $this->paymentMethodMessages->getAndClear();
     }
 
     /**
@@ -134,6 +149,7 @@ class MollieConfigProvider implements ConfigProviderInterface
         $config['payment']['mollie']['creditcard']['use_components'] = $this->config->creditcardUseComponents($storeId);
         $config['payment']['mollie']['applepay']['integration_type'] = $this->config->applePayIntegrationType($storeId);
         $config['payment']['mollie']['applepay']['supported_networks'] = $this->supportedNetworks->execute((int)$storeId);
+        $config['payment']['mollie']['messages'] = $this->getMessages();
         $config['payment']['mollie']['store']['name'] = $storeName;
         $config['payment']['mollie']['store']['currency'] = $this->config->getStoreCurrency($storeId);
         $config['payment']['mollie']['expresscomponents']['enabled'] = $this->getMethodInstance('mollie_methods_expresscomponents')->isAvailable();

--- a/Service/Checkout/PaymentMethodMessages.php
+++ b/Service/Checkout/PaymentMethodMessages.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Service\Checkout;
+
+use Exception;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Message\MessageInterface;
+use Magento\Framework\Phrase;
+
+/**
+ * The checkout page removes the `page.messages` container, so messages that are added right before a redirect to
+ * the checkout have nothing to render them. They are recorded here as well, so that the payment method knows which
+ * of the messages in the shared `mage-messages` cookie were produced by Mollie.
+ */
+class PaymentMethodMessages
+{
+    private const SESSION_KEY = 'mollie_payment_method_messages';
+
+    public function __construct(
+        private Session $checkoutSession,
+        private ManagerInterface $messageManager,
+    ) {}
+
+    public function addNotice(Phrase $message): void
+    {
+        $this->messageManager->addNoticeMessage($message);
+
+        $this->remember(MessageInterface::TYPE_NOTICE, $message);
+    }
+
+    public function addError(Phrase $message): void
+    {
+        $this->messageManager->addErrorMessage($message);
+
+        $this->remember(MessageInterface::TYPE_ERROR, $message);
+    }
+
+    public function addException(Exception $exception, Phrase $message): void
+    {
+        $this->messageManager->addExceptionMessage($exception, $message);
+
+        $this->remember(MessageInterface::TYPE_ERROR, $message);
+    }
+
+    /**
+     * @return array<int, array{type: string, text: string}>
+     */
+    public function getAndClear(): array
+    {
+        return $this->checkoutSession->getData(self::SESSION_KEY, true) ?? [];
+    }
+
+    private function remember(string $type, Phrase $message): void
+    {
+        $messages = $this->checkoutSession->getData(self::SESSION_KEY) ?? [];
+        $messages[] = ['type' => $type, 'text' => (string)$message];
+
+        $this->checkoutSession->setData(self::SESSION_KEY, $messages);
+    }
+}

--- a/Service/Mollie/Order/AddResultMessage.php
+++ b/Service/Mollie/Order/AddResultMessage.php
@@ -8,23 +8,23 @@ declare(strict_types=1);
 
 namespace Mollie\Payment\Service\Mollie\Order;
 
-use Magento\Framework\Message\ManagerInterface;
+use Mollie\Payment\Service\Checkout\PaymentMethodMessages;
 use Mollie\Payment\Service\Mollie\GetMollieStatusResult;
 
 class AddResultMessage
 {
     public function __construct(
-        private ManagerInterface $messageManager
+        private PaymentMethodMessages $paymentMethodMessages
     ) {}
 
     public function execute(GetMollieStatusResult $result): void
     {
         if ($result->getStatus() == 'canceled') {
-            $this->messageManager->addNoticeMessage(__('Payment canceled, please try again.'));
+            $this->paymentMethodMessages->addNotice(__('Payment canceled, please try again.'));
 
             return;
         }
 
-        $this->messageManager->addErrorMessage(__('Transaction failed. Please verify your billing information and payment method, and try again.'));
+        $this->paymentMethodMessages->addError(__('Transaction failed. Please verify your billing information and payment method, and try again.'));
     }
 }

--- a/Test/End-2-end/tests/checkout-messages.spec.ts
+++ b/Test/End-2-end/tests/checkout-messages.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import {expect, Page, test} from '@playwright/test';
+import CheckoutPage from "Pages/frontend/CheckoutPage";
+import CheckoutPaymentPage from "Pages/frontend/CheckoutPaymentPage";
+import CheckoutShippingPage from "Pages/frontend/CheckoutShippingPage";
+import MollieHostedPaymentPage from "Pages/mollie/MollieHostedPaymentPage";
+import VisitCheckoutPaymentCompositeAction from "CompositeActions/VisitCheckoutPaymentCompositeAction";
+import Configuration from "Actions/backend/Configuration";
+
+/**
+ * https://github.com/mollie/magento2/issues/1075
+ */
+
+const checkoutPage = new CheckoutPage();
+const checkoutPaymentPage = new CheckoutPaymentPage();
+const checkoutShippingPage = new CheckoutShippingPage();
+const mollieHostedPaymentPage = new MollieHostedPaymentPage(expect);
+const visitCheckoutPayment = new VisitCheckoutPaymentCompositeAction();
+const configuration = new Configuration(expect);
+
+const REDIRECT_ON_FAILURE_FIELD = 'Redirect user when redirect fails';
+
+/**
+ * Adds a product to the cart without JavaScript, so `Cart\Add::_goBack()` redirects back to the checkout and the
+ * success message ends up in the shared `mage-messages` cookie with nothing on the checkout page to render it.
+ */
+const submitNonAjaxAddToCart = async (page: Page, productId: number) => {
+  await page.evaluate((id) => {
+    const formKey = document.cookie.match(/(?:^|; )form_key=([^;]+)/)[1];
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/checkout/cart/add/product/' + id + '/';
+    form.innerHTML = '<input name="form_key" value="' + formKey + '">' +
+      '<input name="product" value="' + id + '">' +
+      '<input name="qty" value="1">';
+    document.body.appendChild(form);
+    form.submit();
+  }, productId);
+
+  await page.waitForFunction(() => document.cookie.includes('mage-messages='));
+};
+
+const returnToPaymentStep = async (page: Page) => {
+  await checkoutPage.visit(page);
+  await checkoutShippingPage.selectFirstAvailableShippingMethod(page);
+  await checkoutPage.continue(page);
+};
+
+const paymentMethodMessages = (page: Page) => {
+  return page.locator('.payment-method._active [data-role="checkout-messages"]');
+};
+
+const returnFromMollieWithStatus = async (page: Page, status: string) => {
+  await visitCheckoutPayment.visit(page);
+
+  await checkoutPaymentPage.selectPaymentMethod(page, 'iDEAL | Wero');
+  await checkoutPaymentPage.placeOrder(page);
+
+  await mollieHostedPaymentPage.selectFirstIssuer(page);
+  await mollieHostedPaymentPage.selectStatus(page, status);
+
+  await paymentMethodMessages(page).waitFor({ state: 'visible' });
+};
+
+const withRedirectToPaymentStep = async (page: Page, scenario: () => Promise<void>) => {
+  await page.goto('/admin/');
+  await configuration.setValue(
+    page,
+    'Order Management',
+    'Fallback',
+    REDIRECT_ON_FAILURE_FIELD,
+    'redirect_to_checkout_payment'
+  );
+
+  try {
+    await scenario();
+  } finally {
+    await page.goto('/admin/');
+    await configuration.setValue(
+      page,
+      'Order Management',
+      'Fallback',
+      REDIRECT_ON_FAILURE_FIELD,
+      'redirect_to_cart'
+    );
+  }
+};
+
+test('A message from an unrelated controller is not rendered in the payment method', async ({ page }) => {
+  await visitCheckoutPayment.visit(page);
+
+  await submitNonAjaxAddToCart(page, 4);
+  await returnToPaymentStep(page);
+
+  await checkoutPaymentPage.selectPaymentMethod(page, 'iDEAL | Wero');
+
+  await expect(paymentMethodMessages(page)).toBeHidden();
+});
+
+test('A message from an unrelated controller is left for the page it belongs to', async ({ page }) => {
+  await visitCheckoutPayment.visit(page);
+
+  await submitNonAjaxAddToCart(page, 4);
+  await returnToPaymentStep(page);
+
+  await checkoutPaymentPage.selectPaymentMethod(page, 'iDEAL | Wero');
+  await page.goto('/checkout/cart');
+
+  await expect(page.locator('.page.messages .message-success')).toContainText('shopping cart');
+  await expect(page.locator('.page.messages .message-success a')).toHaveCount(1);
+});
+
+test('The payment method shows no messages when nothing produced one', async ({ page }) => {
+  await visitCheckoutPayment.visit(page);
+
+  await checkoutPaymentPage.selectPaymentMethod(page, 'iDEAL | Wero');
+
+  await expect(paymentMethodMessages(page)).toBeHidden();
+});
+
+test('A failed transaction is reported as an error in the payment method', async ({ page }) => {
+  await withRedirectToPaymentStep(page, async () => {
+    await returnFromMollieWithStatus(page, 'failed');
+
+    await expect(paymentMethodMessages(page).locator('.message-error')).toHaveCount(1);
+
+    await page.goto('/checkout/cart');
+
+    await expect(page.locator('.page.messages .message-error')).toHaveCount(0);
+  });
+});
+
+test('A canceled transaction is reported as a notice in the payment method', async ({ page }) => {
+  await withRedirectToPaymentStep(page, async () => {
+    await returnFromMollieWithStatus(page, 'canceled');
+
+    await expect(paymentMethodMessages(page).locator('.message-notice')).toHaveCount(1);
+    await expect(paymentMethodMessages(page).locator('.message-error')).toHaveCount(0);
+  });
+});

--- a/Test/Integration/Service/Checkout/PaymentMethodMessagesTest.php
+++ b/Test/Integration/Service/Checkout/PaymentMethodMessagesTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Mollie\Payment\Test\Integration\Service\Checkout;
+
+use Exception;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Message\MessageInterface;
+use Mollie\Payment\Service\Checkout\PaymentMethodMessages;
+use Mollie\Payment\Test\Integration\IntegrationTestCase;
+
+class PaymentMethodMessagesTest extends IntegrationTestCase
+{
+    private PaymentMethodMessages $instance;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->instance = $this->objectManager->create(PaymentMethodMessages::class);
+        $this->instance->getAndClear();
+        $this->getMessageManagerTexts();
+    }
+
+    public function testRemembersTheTypeAndTextOfEveryMessageItAdds(): void
+    {
+        $this->instance->addNotice(__('Payment canceled, please try again.'));
+        $this->instance->addError(__('Transaction failed.'));
+
+        $this->assertSame([
+            ['type' => MessageInterface::TYPE_NOTICE, 'text' => 'Payment canceled, please try again.'],
+            ['type' => MessageInterface::TYPE_ERROR, 'text' => 'Transaction failed.'],
+        ], $this->instance->getAndClear());
+    }
+
+    public function testForgetsTheMessagesOnceTheyAreRead(): void
+    {
+        $this->instance->addError(__('Transaction failed.'));
+        $this->instance->getAndClear();
+
+        $this->assertSame([], $this->instance->getAndClear());
+    }
+
+    public function testReturnsAnEmptyArrayWhenNothingWasAdded(): void
+    {
+        $this->assertSame([], $this->instance->getAndClear());
+    }
+
+    public function testAlsoAddsTheMessageToTheMessageManager(): void
+    {
+        $this->instance->addError(__('Transaction failed.'));
+
+        $this->assertSame(['Transaction failed.'], $this->getMessageManagerTexts());
+    }
+
+    public function testRemembersTheAlternativeTextWhenAnExceptionIsAdded(): void
+    {
+        $this->instance->addException(
+            new Exception('Connection refused'),
+            __('There was an error checking the transaction status.')
+        );
+
+        $this->assertSame([
+            ['type' => MessageInterface::TYPE_ERROR, 'text' => 'There was an error checking the transaction status.'],
+        ], $this->instance->getAndClear());
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getMessageManagerTexts(): array
+    {
+        /** @var ManagerInterface $messageManager */
+        $messageManager = $this->objectManager->get(ManagerInterface::class);
+
+        return array_map(
+            fn (MessageInterface $message): string => $message->getText(),
+            $messageManager->getMessages(true)->getItems()
+        );
+    }
+}

--- a/Test/Integration/Service/Checkout/PaymentMethodMessagesTest.php
+++ b/Test/Integration/Service/Checkout/PaymentMethodMessagesTest.php
@@ -16,7 +16,7 @@ use Mollie\Payment\Test\Integration\IntegrationTestCase;
 
 class PaymentMethodMessagesTest extends IntegrationTestCase
 {
-    private PaymentMethodMessages $instance;
+    private ?PaymentMethodMessages $instance = null;
 
     protected function setUp(): void
     {

--- a/view/frontend/web/js/model/messages.js
+++ b/view/frontend/web/js/model/messages.js
@@ -1,0 +1,39 @@
+define(
+    [
+        'ko',
+        'Magento_Ui/js/model/messages'
+    ],
+    function (ko, Messages) {
+        'use strict';
+
+        /**
+         * `Magento_Ui/js/model/messages` only knows errors and successes, so a notice added by Mollie would end up
+         * in a red box. This adds the third list, rendered by `Mollie_Payment/messages`.
+         */
+        return Messages.extend(
+            {
+                initObservable: function () {
+                    this._super();
+
+                    this.noticeMessages = ko.observableArray([]);
+
+                    return this;
+                },
+                addNoticeMessage: function (message) {
+                    return this.add(message, this.noticeMessages);
+                },
+                getNoticeMessages: function () {
+                    return this.noticeMessages;
+                },
+                hasMessages: function () {
+                    return this._super() || this.noticeMessages().length > 0;
+                },
+                clear: function () {
+                    this._super();
+
+                    this.noticeMessages.removeAll();
+                }
+            }
+        );
+    }
+);

--- a/view/frontend/web/js/view/payment/method-renderer/default.js
+++ b/view/frontend/web/js/view/payment/method-renderer/default.js
@@ -1,36 +1,42 @@
 define(
     [
         'jquery',
-        'underscore',
         'ko',
         'mage/url',
         'mage/storage',
         'mage/translate',
+        'uiLayout',
         'Magento_Checkout/js/view/payment/default',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/checkout-data',
         'Magento_Customer/js/model/customer',
         'Magento_Checkout/js/model/url-builder',
         'Mollie_Payment/js/model/checkout-config',
+        'Mollie_Payment/js/model/messages',
         'jquery/jquery-storageapi'
     ],
     function (
         $,
-        _,
         ko,
         url,
         storage,
         $t,
+        layout,
         Component,
         quote,
         checkoutData,
         customer,
         urlBuilder,
-        checkoutConfigData
+        checkoutConfigData,
+        Messages
     ) {
         'use strict';
 
         var checkoutConfig = window.checkoutConfig.payment;
+        var messageContainerMethods = {
+            success: 'addSuccessMessage',
+            notice: 'addNoticeMessage'
+        };
 
         return Component.extend(
             {
@@ -52,6 +58,30 @@ define(
                     if (this.getCode() === this.isChecked()) {
                         this.renderMessages();
                     }
+
+                    return this;
+                },
+                /**
+                 * Replaces the message container and its renderer with the Mollie variants, which can render a
+                 * notice instead of collapsing it into an error.
+                 */
+                initChildren: function () {
+                    this.messageContainer = new Messages();
+                    this.createMessagesComponent();
+
+                    return this;
+                },
+                createMessagesComponent: function () {
+                    layout([{
+                        parent: this.name,
+                        name: this.name + '.messages',
+                        displayArea: 'messages',
+                        component: 'Magento_Ui/js/view/messages',
+                        config: {
+                            messageContainer: this.messageContainer,
+                            template: 'Mollie_Payment/messages'
+                        }
+                    }]);
 
                     return this;
                 },
@@ -137,28 +167,62 @@ define(
                     return url.build('mollie/checkout/redirect/paymentToken/' + this.paymentToken());
                 },
                 renderMessages: function () {
-                    // Copied from Magento_Theme/js/view/messages
-                    var messages = _.unique($.cookieStorage.get('mage-messages'), 'text');
-
-                    $.each(messages, function (index, row) {
-                        if (row.type === 'success') {
-                            this.messageContainer.addSuccessMessage({message: row.text});
-                        } else {
-                            this.messageContainer.addErrorMessage({message: row.text});
-                        }
-                    }.bind(this));
-
-                    // Copied from Magento_Theme/js/view/messages
-                    $.mage.cookies.set('mage-messages', '', {
-                        samesite: 'strict',
-                        domain: ''
-                    });
+                    var messages = this.takeMollieMessages();
 
                     if (!messages.length) {
                         return;
                     }
 
-                    // Make sure the messages are visible
+                    this.removeFromPageMessages(messages);
+
+                    $.each(messages, function (index, row) {
+                        var method = messageContainerMethods[row.type] || 'addErrorMessage';
+
+                        this.messageContainer[method]({message: row.text});
+                    }.bind(this));
+
+                    this.scrollToMessages();
+                },
+                /**
+                 * The messages Mollie added right before redirecting back to the checkout. They are consumed once,
+                 * so selecting a second payment method does not render them again.
+                 */
+                takeMollieMessages: function () {
+                    var messages = (checkoutConfig.mollie && checkoutConfig.mollie.messages) || [];
+
+                    if (checkoutConfig.mollie) {
+                        checkoutConfig.mollie.messages = [];
+                    }
+
+                    return messages;
+                },
+                /**
+                 * The `mage-messages` cookie is shared with the rest of the shop and the checkout page has no
+                 * renderer to empty it, so only the messages rendered here are removed. Anything else stays behind
+                 * for the page it belongs to.
+                 */
+                removeFromPageMessages: function (messages) {
+                    var pageMessages = $.cookieStorage.get('mage-messages');
+
+                    if (!Array.isArray(pageMessages)) {
+                        return;
+                    }
+
+                    var rendered = messages.map(function (row) {
+                        return row.text;
+                    });
+
+                    var remaining = pageMessages.filter(function (row) {
+                        return rendered.indexOf(row.text) === -1;
+                    });
+
+                    // Copied from Magento_Theme/js/view/messages
+                    $.mage.cookies.set('mage-messages', remaining.length ? JSON.stringify(remaining) : '', {
+                        samesite: 'strict',
+                        domain: ''
+                    });
+                },
+                scrollToMessages: function () {
                     var attempts = 0;
                     var interval = setInterval(function () {
                         attempts++;

--- a/view/frontend/web/template/messages.html
+++ b/view/frontend/web/template/messages.html
@@ -1,0 +1,23 @@
+<!--
+/**
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<div data-role="checkout-messages" class="messages" data-bind="visible: isVisible(), click: removeAll">
+    <!-- ko foreach: messageContainer.getErrorMessages() -->
+    <div aria-atomic="true" role="alert" class="message message-error error">
+        <div data-ui-id="mollie-payment-message-error" data-bind="text: $data"></div>
+    </div>
+    <!--/ko-->
+    <!-- ko foreach: messageContainer.getNoticeMessages() -->
+    <div aria-atomic="true" role="alert" class="message message-notice notice">
+        <div data-ui-id="mollie-payment-message-notice" data-bind="text: $data"></div>
+    </div>
+    <!--/ko-->
+    <!-- ko foreach: messageContainer.getSuccessMessages() -->
+    <div aria-atomic="true" role="alert" class="message message-success success">
+        <div data-ui-id="mollie-payment-message-success" data-bind="text: $data"></div>
+    </div>
+    <!--/ko-->
+</div>


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [ ] The code is working on a plain Magento 2 installation.
- [ ] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [ ] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [ ] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [ ] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i...

**Scenario to test this code:**

Open the environment and...